### PR TITLE
fix persistent_disk_type/pool issue

### DIFF
--- a/base/base.yml
+++ b/base/base.yml
@@ -16,6 +16,7 @@ instance_groups:
   - name: (( grab params.bosh_network ))
     static_ips: [(( grab params.static_ip ))]
   vm_type: (( grab params.bosh_vm_type ))
+  persistent_disk_type: (( grab params.bosh_disk_pool ))
 
 meta:
   vault: (( concat "secret/" params.vault ))

--- a/subkits/bosh-init/init.yml
+++ b/subkits/bosh-init/init.yml
@@ -19,6 +19,7 @@ instance_groups:
 - name: bosh
   resource_pool: (( grab params.bosh_vm_type ))
   vm_type: (( prune ))
+  persistent_disk_type: (( prune ))
   persistent_disk_pool: (( grab params.bosh_disk_pool ))
 
 networks:

--- a/subkits/bosh/params.yml
+++ b/subkits/bosh/params.yml
@@ -7,3 +7,4 @@ cloud_provider: ~
 instance_groups:
 - name: bosh
   resource_pool: (( prune ))
+  persistent_disk_pool: (( prune ))

--- a/subkits/vsphere-cpi/vsphere.yml
+++ b/subkits/vsphere-cpi/vsphere.yml
@@ -14,11 +14,6 @@ instance_groups:
   jobs:
   - name: vsphere_cpi
     release: bosh-vsphere-cpi
-  # In cloud config, define a disk_type using name: bosh
-  persistent_disk_type: bosh
-  # In cloud config, define a vm_type using name: small
-  vm_type: small
-
   properties:
     vcenter:
       user:           (( vault meta.vault "/vsphere:user" ))


### PR DESCRIPTION
When using bosh to deploy another bosh, bosh director complained that both `persistent_disk_type` and `persistent_disk_pool` defined.