### PR TITLE
Support Trusted Certs

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -20,6 +20,11 @@ director.
 - `bosh_hostname` - The hostname to assign the BOSH director.
   Defaults to `bosh`.
 
+- `trusted_certs` - An optional list of PEM-encoded CA
+  certificates, which will be installed on all BOSH-deployed VMs
+  as part of the trusted system root bundle.
+
+
 ## Sizing and Deployment Parameters
 
 - `bosh_network` - The name of the network (per cloud-config) where

--- a/manifests/bosh/bosh.yml
+++ b/manifests/bosh/bosh.yml
@@ -126,6 +126,8 @@ instance_groups:
       events:
         record_events: true
 
+      trusted_certs: (( grab params.trusted_certs || ~ ))
+
     hm:
       resurrector_enabled: true
       director_account:


### PR DESCRIPTION
New `trusted_certs` parameter allows operators to specify a list of
X.509 Certificate Authorities to trust by default, on BOSH itself and on
all VMs that BOSH deploys.

Fixes #29