### PR TITLE
Better Certificate Checking

### DIFF
--- a/hooks/check
+++ b/hooks/check
@@ -32,22 +32,30 @@ fi
 ip=$(lookup params.static_ip)
 describe "  checking if our certificates match the director static ip ($ip)..."
 vault="secret/$GENESIS_VAULT_PREFIX"
-for cert in ssl/{server,mbus,uaa,uaa-sp} \
-            credhub/server \
-            nats/{server,director,health/monitor}; do
+check_cert() {
+  cert=$1 ; shift
   if ! safe exists "$vault/$cert"; then
     describe "    - $vault/$cert [#Y{MISSING}]"
+    ok=no
   else
-    if safe --quiet x509 validate "$vault/$cert" --for "$ip" >/dev/null 2>&1; then
+    if safe --quiet x509 validate "$vault/$cert" "$@" >/dev/null 2>&1; then
       describe "    - $vault/$cert [#G{OK}]"
     else
       describe "    - $vault/$cert [#R{INVALID}]"
-      safe x509 validate "$vault/$cert" --for "$ip" 2>&1 | sed -e 's/^/      /';
+      safe x509 validate "$vault/$cert" "$@" >&1 | sed -e 's/^/      /';
       ok=no
       echo
     fi
   fi
-done
+}
+check_cert ssl/server          --for $ip
+check_cert ssl/mbus            --for $ip
+check_cert ssl/uaa             --for $ip
+check_cert ssl/uaa-sp          --for $ip
+check_cert credhub/server      --for $ip
+check_cert nats/server         --for $ip --for default.nats.bosh-internal
+check_cert nats/director       --for $ip --for default.director.bosh-internal
+check_cert nats/health/monitor --for $ip --for default.hm.bosh-internal
 
 if [[ "$ok" = "yes" ]]; then
   describe "  environment files [#G{OK}]"

--- a/kit.yml
+++ b/kit.yml
@@ -14,16 +14,10 @@ certificates:
         valid_for: 1y
         names:
         - ${params.static_ip}
-          # FIXME: bosh_hostname not resolving a default.
-          # can we do - ${params.bosh_hostname:bosh-${params.env}}?
-          # i.e. nest the deref with a default after the ':' ?
-          #- ${params.bosh_hostname}
       mbus:
         valid_for: 1y
         names:
         - ${params.static_ip}
-          # FIXME: bosh_hostname not resolving a default.
-          #- ${params.bosh_hostname}
       uaa:
         valid_for: 1y
         names:
@@ -48,22 +42,16 @@ certificates:
         names:
         - default.nats.bosh-internal
         - ${params.static_ip}
-          # FIXME: bosh_hostname not resolving a default.
-          #- ${params.bosh_hostname}
       director:
         valid_for: 1y
         names:
         - default.director.bosh-internal
         - ${params.static_ip}
-          # FIXME: bosh_hostname not resolving a default.
-          #- ${params.bosh_hostname}
       health/monitor:
         valid_for: 1y
         names:
         - default.hm.bosh-internal
         - ${params.static_ip}
-          # FIXME: bosh_hostname not resolving a default.
-          #- ${params.bosh_hostname}
 
 credentials:
   base:


### PR DESCRIPTION
BOSH + gnatsd need to agree on names for the certificates that will be
used when dealing with nats over TLS.  The nats job configuration
hardcodes names that MUST be present as the subject of each of the
server / client / hm nats certs.

Now we check those assertions explicitly during `hooks check`, to make
sure we don't deploy unusable certificates.