### PR TITLE
Protect more passwords / keys from rotation

### DIFF
--- a/kit.yml
+++ b/kit.yml
@@ -56,15 +56,15 @@ certificates:
 credentials:
   base:
     blobstore/agent:
-      password: random 64
+      password: random 64 fixed
     blobstore/director:
       password: random 64
     db:
       password: random 64
     nats:
-      password: random 64
+      password: random 64 fixed
     registry:
-      password: random 64
+      password: random 64 fixed
 
     users/admin:
       password: random 30
@@ -76,7 +76,7 @@ credentials:
       password: random 64 fmt crypt-sha512
 
     credhub/encryption:
-      key: random 32
+      key: random 32 fixed
 
     uaa/jwt: rsa 2048
 


### PR DESCRIPTION
- The blobstore agent password is present on deployed-vm configuration,
  and therefore must not change automatically.

- The nats password (for what use it will have in the near future) is
  also on deployed VMs in their agent configurations and should not
  change.

- The registry password should be fixed as well, just in case.

- The credhub encrpytion keys should not rotate; that would be ...
  not good for encrpyted secrets stored in credhub at the time of
  secrets rotation.