### PR TITLE
fixed manifest mergeing issue with trusted_certs due to null

### DIFF
--- a/manifests/bosh/bosh.yml
+++ b/manifests/bosh/bosh.yml
@@ -126,7 +126,7 @@ instance_groups:
       events:
         record_events: true
 
-      trusted_certs: (( grab params.trusted_certs || ~ ))
+      trusted_certs: (( grab params.trusted_certs || "" ))
 
     hm:
       resurrector_enabled: true


### PR DESCRIPTION
With `trusted_certs: (( grab params.trusted_certs || ~ ))`, when trusted_certs is configured, it will be not merged into manifest; change it to `trusted_certs: (( grab params.trusted_certs || "" ))`fixed it