### PR TITLE
Upgrade the default BOSH VM Type to large

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -40,7 +40,7 @@ director.
 
 - `bosh_vm_type` - The name of the `vm_type` (per cloud-config) that
   will be used to deploy the BOSH director VM.  Defaults to
-  `small`.
+  `large`.
 
 - `bosh_disk_pool` - The name of the `disk_type` (per cloud-config)
   that will be used to back the persistent storage of the BOSH

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -12,6 +12,10 @@ This release updates several of the core components and BOSH CPIs.
   release, and will continue to receive security updates through
   April of 2021.  Trusty Tahr 14.04 is EOL as of April 2019.
 
+- The default `bosh_vm_type` has changed from `small` to `large`.
+  If you deployed BOSH using the defaults, upgrading to this kit
+  version will incur a rebuild of the BOSH VM.
+
 # Core Components
 
 | Release | Version | Release Date |

--- a/hooks/check
+++ b/hooks/check
@@ -4,7 +4,7 @@
 ok=yes
 if [[ -n "$GENESIS_CLOUD_CONFIG" ]] ; then
   if ! want_feature proto; then
-    cloud_config_needs vm_type    $(lookup params.bosh_vm_type   small)
+    cloud_config_needs vm_type    $(lookup params.bosh_vm_type   large)
     cloud_config_needs network    $(lookup params.bosh_network   bosh)
     cloud_config_needs disk_type  $(lookup params.bosh_disk_pool bosh)
 

--- a/manifests/bosh/bosh.yml
+++ b/manifests/bosh/bosh.yml
@@ -4,9 +4,9 @@ meta:
     azs: [z1]
 
 params:
-  bosh_network: bosh
+  bosh_network:   bosh
   bosh_disk_pool: bosh
-  bosh_vm_type: small
+  bosh_vm_type:   large
 
   session_timeout: 1 # In days
 


### PR DESCRIPTION
It used to be small, but this is too small.