### PR TITLE
Resolve issues deploying AWS env BOSHes not using cc vm_types

### DIFF
--- a/manifests/iaas/aws.yml
+++ b/manifests/iaas/aws.yml
@@ -25,15 +25,6 @@ instance_groups:
     director:
       cpi_job: aws_cpi
 
-vm_types:
-- name: (( grab params.bosh_vm_type ))
-  cloud_properties:
-    instance_type: (( grab params.aws_instance_type ))
-    ephemeral_disk:
-      type: (( grab params.aws_disk_type ))
-      size: (( grab params.ephemeral_disk_size ))
-    availability_zone: (( grab instance_groups.bosh.azs[0] ))
-
 releases:
 - name:    bosh-aws-cpi
   version: 72


### PR DESCRIPTION
env BOSHes in AWS currently do not properly use vm_types in the cloud-config as they are being overridden manually. Pulling this allows the deployment to properly use cloud-config vm_types.