### PR TITLE
Update AWS default ntp servers

### DIFF
--- a/manifests/iaas/aws.yml
+++ b/manifests/iaas/aws.yml
@@ -4,6 +4,10 @@ params:
   aws_region:      (( param "What AWS region are you going to use?" ))
   aws_default_sgs: (( param "What security groups should VMs be placed in, if none are specified via Cloud Config?" ))
 
+  ntp: # use AWS ntp
+  - (( replace ))
+  - 169.254.169.123
+
 meta:
   default:
     azs:


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html we should be using `169.254.169.123` as the default for AWS instances. The default of 0.pool and 1.pool were not behaving correctly out of the box within a secured VPC.