### PR TITLE
adding support for aws ebs encryption

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -151,6 +151,9 @@ requires a bit more configuration:
   - `aws_disk_type` - What type of disk to use for the proto-BOSH
     director's persistent storage.  Defaults to `gp2`.
 
+If you activate the `aws-ebs-encryption` feature, you will enable 
+    Amazon EBS volume encrpytion for ephemeral disk.
+
 ## Deploying to Microsoft Azure
 
 To deploy a BOSH director onto Microsoft's Azure cloud platform,

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -7,3 +7,5 @@
   - Azure moved from `Standard_D1_v2` to `Standard_D2_v2`
   - Google moved from `n1-standard-1` to `n1-standard-2`
   - vSphere moved from 2 core / 4GB RAM to 2 core / 8GB
+
+- Added support for AWS ebs volume encryption for ephemeral disk.

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -6,7 +6,7 @@ declare -a merge
 validate_features aws azure google openstack vsphere warden \
                   aws-cpi azure-cpi google-cpi openstack-cpi vsphere-cpi warden-cpi \
                   aws-init azure-init google-init openstack-init vsphere-init bosh-init \
-                  proxy credhub shield bosh proto skip-op-users
+                  proxy credhub shield bosh proto skip-op-users aws-ebs-encryption
 
 #
 # We always start out with the skeleton of a BOSH deployment,
@@ -52,6 +52,10 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
                manifests/proto/$want.yml )
     else
       merge+=( manifests/bosh/env.yml )
+    fi
+
+    if want_feature aws-ebs-encryption; then
+      merge+=( manifests/addons/aws-ebs-encryption.yml )
     fi
 
     if want_feature "${want}-init"; then

--- a/manifests/addons/aws-ebs-encryption.yml
+++ b/manifests/addons/aws-ebs-encryption.yml
@@ -1,0 +1,6 @@
+---
+instance_groups:
+- name: bosh
+  properties:
+    aws:
+      encrypted: true


### PR DESCRIPTION
This allows the bosh kit to take advantage of ebs encryption in aws for ephemeral disk.