### PR TITLE
Adding support for EBS encryption in AWS

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -126,6 +126,9 @@ To deploy a BOSH director onto Amazon Web Services, activate the
   - `aws_key_name` - The name of the EC2 keypair to use when
     deploying EC2 instances.  This defaults to `vcap@params.env`.
 
+  - `aws_ebs_encrpytion` - Enables Amazon EBS volume encrpytion 
+    for ephemeral disk (defaults to `false`).
+
 The following secrets will be pulled from the vault:
 
   - **Access Key** - The Amazon Access Key ID (and its counterpart

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -7,3 +7,5 @@
   - Azure moved from `Standard_D1_v2` to `Standard_D2_v2`
   - Google moved from `n1-standard-1` to `n1-standard-2`
   - vSphere moved from 2 core / 4GB RAM to 2 core / 8GB
+
+- Added parameter to support AWS ebs volume encryption for ephemeral disk.

--- a/manifests/iaas/aws.yml
+++ b/manifests/iaas/aws.yml
@@ -3,6 +3,7 @@ params:
   aws_key_name:    (( concat "vcap@" params.env ))
   aws_region:      (( param "What AWS region are you going to use?" ))
   aws_default_sgs: (( param "What security groups should VMs be placed in, if none are specified via Cloud Config?" ))
+  aws_ebs_encryption: false
 
   ntp: # use AWS ntp
   - (( replace ))
@@ -26,6 +27,7 @@ instance_groups:
       default_key_name:        (( grab params.aws_key_name ))
       default_security_groups: (( grab params.aws_default_sgs ))
       region:                  (( grab params.aws_region ))
+      encrypted:               (( grab params.aws_ebs_encryption ))
     director:
       cpi_job: aws_cpi
 


### PR DESCRIPTION
This allows the bosh kit to take advantage of ebs encryption in aws for ephemeral disk.