### PR TITLE
Improve credhub access

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,6 @@
+# New Features
+
+* Improved access to the credhub located on the BOSH director
+  - Provides the `credhub-login` addon to target and log into credhub
+  - Provides credhub connection data in exodus for use with other kits
+

--- a/hooks/addon
+++ b/hooks/addon
@@ -154,6 +154,20 @@ upload_stemcells() {
   fi
 }
 
+credhub_login() {
+  # Check for credhub command
+  which credhub > /dev/null 2>&1 || _bail "Command 'credhub' not found.  Please install from https://github.com/cloudfoundry-incubator/credhub-cli"
+
+  # Update api target with correct ca's
+  credhub api https://$(lookup params.static_ip):8844 --ca-cert <(safe read $vault/ssl/ca:certificate; safe read $vault/credhub/ca:certificate)
+
+  # Login via stored password
+  credhub login -u credhub-cli -p "$(safe read $vault/uaa/users/credhub-cli:password)"
+  echo
+  credhub --version
+  echo
+}
+
 list() {
   echo "The following addons are defined:"
   echo
@@ -164,6 +178,8 @@ list() {
   echo "  upload-stemcells     Upload the appropriate BOSH stemcells"
   echo
   echo "  runtime-config       Generate a base runtime config and upload it"
+  echo
+  echo "  credhub-login        Target and log in to credhub on this bosh director"
   echo
 }
 
@@ -185,6 +201,10 @@ login)
 logout)
   setup_alias >/dev/null
   bosh -e $GENESIS_ENVIRONMENT logout
+  ;;
+
+credhub-login)
+  credhub_login
   ;;
 
 upload-stemcells|us)

--- a/kit.yml
+++ b/kit.yml
@@ -26,13 +26,13 @@ certificates:
         valid_for: 1y
         names:
         - ${params.static_ip}
+
     blobstore:
       ca: { valid_for: 1y }
       server:
         valid_for: 1y
         names:
         - ${params.static_ip}
-
 
     credhub:
       ca: { valid_for: 1y }

--- a/manifests/bosh/bosh.yml
+++ b/manifests/bosh/bosh.yml
@@ -21,6 +21,11 @@ exodus:
   admin_username: admin
   admin_password: (( vault meta.vault "/users/admin:password" ))
 
+  credhub_url:      (( concat "https://" params.static_ip ":8844" ))
+  credhub_ca_cert:  (( vault meta.vault "/credhub/ca:certificate" ))
+  credhub_username: credhub-cli
+  credhub_password: (( vault meta.vault "/uaa/users/credhub-cli:password" ))
+
 name: (( grab params.name ))
 
 releases:


### PR DESCRIPTION
# New Features

* Improved access to the credhub located on the BOSH director
  - Provides the `credhub-login` addon to target and log into credhub
  - Provides credhub connection data in exodus for use with other kits