### PR TITLE
Genesis v2.7.0 improvements

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,10 +1,10 @@
 # New Features
 
-* Added new feature `vault-credhub-proxy`.
+* Added new feature `vault-credhub-proxy`:
   - Provides communication with BOSH internal credhub using [safe](https://github.com/starkandwayne/safe)
   - Provides the `vault-proxy-login` addon to target and log into credhub using safe.
 
-* Added new feature `external-db`.
+* Added new feature `external-db`:
   - Support for using an external postgres database for BOSH, Credhub, and UAA.
     This does not provide any auto data migration from existing internal 
     databases. Users and passwords for the required database users will be 
@@ -14,6 +14,16 @@
     a CA for the external database, use the feature `external-db-ca` and specify 
     the param `external_db_ca` in the environment yaml. 
   - TLS can be disabled with the feature `external-db-no-tls`. 
+
+* Addon `upload-stemcells` Improvements:
+  - Supports --light option to upload light stemcells (available for some
+    platforms)
+  - Supports --os option for specifying an os other than the default of 
+    ubuntu-xenial.  This works in both interactive and specified-versions
+    mode.
+  - Supports alternative specified-versions move syntax:  you can specify just
+    the <version> as before or <os>@<version> (ie ubuntu-trusty@3541.65 or
+    ubuntu-xenial@621.latest)
 
 # Software Updates
 

--- a/ci/test_params.yml
+++ b/ci/test_params.yml
@@ -1,0 +1,4 @@
+---
+params:
+  ca_validity_period:   5y
+  cert_validity_period: 1y

--- a/hooks/addon
+++ b/hooks/addon
@@ -79,10 +79,8 @@ upload_stemcell() {
 }
 
 upload_stemcells() {
-  local os=${1:-ubuntu-xenial}
-
   # Determine cpi
-  local cpi prev_cpi prev_cpi_feature feature
+  local cpi prev_cpi prev_cpi_feature want
   for want in ${GENESIS_REQUESTED_FEATURES}; do
     case "$want" in
       aws|aws-cpi)              cpi="aws-xen-hvm" ;;
@@ -110,43 +108,63 @@ upload_stemcells() {
     exit 1
   fi
 
-  local target="bosh-$cpi-$os-go_agent" fix=""
+  local fix="" os="ubuntu-xenial"
   local stemcells
-  stemcells="$(curl -s "https://bosh.io/api/v1/stemcells/${target}?all=0")"
   declare -a versions
   versions=()
   while test $# -gt 0 ; do
     case "$1" in
       --fix) fix=" --fix" ;;
+      --os)  os="$2"; shift;;
       --*)   describe "#R{[ERROR]} Bad option $1" && exit 1 ;;
-      *)     versions+=($1) ;;
+      *)     if [[ "$1" =~ .*@.* ]]; then versions+=("$1"); else versions+=("$os@$1"); fi;;
     esac
     shift
   done
 
   if [[ ${#versions[@]} -gt 0 ]] ; then
+    declare -a oses
+    declare -a stemcells_for_oses
     local req
     for req in "${versions[@]}" ; do
+      IFS="@" read -r req_os req_version <<< "$req"
+      i=0; while [[ $i -lt ${#oses[@]} ]] ; do
+        [[ ${oses[$i]} == "$req_os" ]] && break
+        ((i++))
+      done
+      if  [[ $i -eq ${#oses[@]} ]] ; then
+        oses+=("$req_os")
+        target="bosh-$cpi-$req_os-go_agent"
+        stemcells_for_oses+=("$(curl -s "https://bosh.io/api/v1/stemcells/${target}?all=0")")
+      fi
+
       # Upload specified stemcells
       local pattern match version url sha1
-      pattern="$(echo "$req" | sed -e 's/\.latest$/\.[0-9]+/')"
-      match="$(echo "$stemcells" | jq --arg re "^$pattern\$" '.[] | select(.regular? and (.version|test($re)))' | jq -Ms '.')"
+      # shellcheck disable=2001
+      pattern="$(echo "$req_version" | sed -e 's/\.latest$/\.[0-9]+/')"
+      match="$( \
+        echo "${stemcells_for_oses[$i]}" | \
+        jq --arg re "^$pattern\$" '.[] | select(.regular? and (.version|test($re)))' | \
+        jq -Ms '.')"
       version="$(echo "$match" | jq -Mr '.[] | .version' | sort -n -t. -k1 -k2 -k3 -k4| tail -n1)"
       if [[ -z "$version" ]] ; then
-        describe "#R{[ERROR]} No version found matching $req"
+        describe "#R{[ERROR]} No version found matching $req_version for OS $req_os"
       else
-        if [[ "$version" != "$req" ]] ; then
-          describe "Using best match to #C{$req}: #G{$version}"
+        if [[ "$version" != "$req_version" ]] ; then
+          describe "Using best match to #C{$req_version}: #G{$version}"
         fi
-        upload_stemcell "$os" "$cpi" "$version" "$fix" "$match"
+        upload_stemcell "$req_os" "$cpi" "$version" "$fix" "$match"
       fi
     done
   else
+    target="bosh-$cpi-$os-go_agent"
+    stemcells="$(curl -s "https://bosh.io/api/v1/stemcells/${target}?all=0")"
     while true; do
       opts=()
       while read -r count major ; do
         opts+=("-o" "[$major] $major.x ($count minor versions available)")
       done <<< "$(echo "$stemcells" | jq -r '.[] | .version' | cut -d. -f1 | sort -nr | uniq -c)"
+      major_sc_version= # Assigned below
       prompt_for major_sc_version "select" "Select the release family for the $cpi $os stemcell you wish to upload:" "${opts[@]}"
 
       opts=()
@@ -156,6 +174,7 @@ upload_stemcells() {
       prompt_for version "select" "Select one of the available $major_sc_version.x versions:" "${opts[@]}"
       upload_stemcell "$os" "$cpi" "$version" "$fix" "$stemcells"
       rc=$?
+      continue= # Assigned below
       prompt_for continue boolean "Upload another?" --default "no"
       [[ "$continue" == "true" ]] || exit $rc
     done
@@ -205,18 +224,32 @@ vault_proxy_login() {
 }
 
 list() {
-  echo "The following addons are defined:"
-  echo
-  echo "  alias                Set up a local bosh alias for a director"
-  echo
-  echo "  login                Log into an (aliased) director"
-  echo
-  echo "  upload-stemcells     Upload the appropriate BOSH stemcells"
-  echo
-  echo "  runtime-config       Generate a base runtime config and upload it"
-  echo
-  echo "  credhub-login        Target and log in to credhub on this bosh director"
-  echo
+  gtest ui-describe "$(cat <<EOF
+The following addons are defined:
+
+  alias                Set up a local bosh alias for a director
+
+  login                Log into an (aliased) director
+
+  upload-stemcells     Upload the appropriate BOSH stemcells. Supports the
+                       following options and arguments:
+
+    --fix              upload the stemcell even if its already uploaded
+    --os <str>         use the os <str> (defaults to ubuntu-xenial)
+
+    <version>...       specify one or more versions of default or last
+                       specified --os option
+
+    <os>@<version>...  specify one or more versions of the given OS
+
+                       Will be interactive if no version is specified
+
+  runtime-config       Generate a base runtime config and upload it
+
+  credhub-login        Target and log in to credhub on this bosh director
+
+EOF
+)"
   if want_feature vault-credhub-proxy; then
     echo "  vault-proxy-login    Target and log into credhub via vault proxy using safe"
     echo

--- a/hooks/addon
+++ b/hooks/addon
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eu
-vault="secret/$GENESIS_VAULT_PREFIX"
 export BOSH_ENVIRONMENT=""
 export BOSH_CA_CERT=""
 export BOSH_CLIENT=""
@@ -21,9 +20,9 @@ bosh() {
 
 setup_alias() {
   BOSH_ENVIRONMENT="$BOSH_URL" \
-    BOSH_CA_CERT=$(safe read $vault/ssl/ca:certificate) \
+    BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
     BOSH_CLIENT="admin" \
-    BOSH_CLIENT_SECRET="$(safe read ${vault}/users/admin:password)" \
+    BOSH_CLIENT_SECRET="$(safe read ${GENESIS_SECRETS_BASE}users/admin:password)" \
     bosh alias-env --tty $GENESIS_ENVIRONMENT| grep -v '^User'
 }
 
@@ -43,7 +42,7 @@ is_logged_in() {
 
 login() {
   echo "Logging you in as user 'admin'..."
-  printf "%s\n%s\n" admin "$(safe read $vault/users/admin:password)" | \
+  printf "%s\n%s\n" admin "$(safe read ${GENESIS_SECRETS_BASE}users/admin:password)" | \
     BOSH_ENVIRONMENT="" \
     BOSH_CA_CERT="" \
     BOSH_CLIENT="" \
@@ -63,9 +62,9 @@ upload_stemcell() {
     "  * SHA1:    #C{$sha1}" \
     ""
   BOSH_ENVIRONMENT=$BOSH_URL \
-    BOSH_CA_CERT=$(safe read $vault/ssl/ca:certificate) \
+    BOSH_CA_CERT=$(safe read ${GENESIS_SECRETS_BASE}ssl/ca:certificate) \
     BOSH_CLIENT="admin" \
-    BOSH_CLIENT_SECRET="$(safe read ${vault}/users/admin:password)" \
+    BOSH_CLIENT_SECRET="$(safe read ${GENESIS_SECRETS_BASE}users/admin:password)" \
     bosh upload-stemcell${fix} --sha1 "$sha1" "$url"
   return $?
 }
@@ -159,10 +158,10 @@ credhub_login() {
   command -v credhub > /dev/null 2>&1 || _bail "Command 'credhub' not found.  Please install from https://github.com/cloudfoundry-incubator/credhub-cli"
 
   # Update api target with correct ca's
-  command credhub api https://$(lookup params.static_ip):8844 --ca-cert <(safe read $vault/ssl/ca:certificate; safe read $vault/credhub/ca:certificate)
+  command credhub api https://$(lookup params.static_ip):8844 --ca-cert <(safe read ${GENESIS_SECRETS_BASE}ssl/ca:certificate; safe read ${GENESIS_SECRETS_BASE}credhub/ca:certificate)
 
   # Login via stored password
-  command credhub login -u credhub-cli -p "$(safe read $vault/uaa/users/credhub-cli:password)"
+  command credhub login -u credhub-cli -p "$(safe read ${GENESIS_SECRETS_BASE}uaa/users/credhub-cli:password)"
   echo
   command credhub --version
   echo
@@ -176,7 +175,7 @@ vault_proxy_login() {
   echo
   ip="$(lookup params.static_ip)"
   proxy="${GENESIS_ENVIRONMENT}-proxy"
-  password="$(safe read $vault/uaa/users/credhub-admin:password)"
+  password="$(safe read ${GENESIS_SECRETS_BASE}uaa/users/credhub-admin:password)"
   export SAFE_TARGET=""
   safe target https://$ip:8200 -k --no-strongbox $proxy
   echo "credhub-admin:$password" | safe -T $proxy auth token
@@ -269,9 +268,9 @@ runtime-config|rc)
 
   (set +e
    BOSH_ENVIRONMENT=$BOSH_URL \
-   BOSH_CA_CERT=$(safe read $vault/ssl/ca:certificate) \
+   BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
    BOSH_CLIENT="admin" \
-   BOSH_CLIENT_SECRET="$(safe read ${vault}/users/admin:password)" \
+   BOSH_CLIENT_SECRET="$(safe read "${GENESIS_SECRETS_BASE}users/admin:password")" \
    bosh runtime-config) | sed -e 's/\s+//' > rc.yml
 
   if [[ ! -s rc.yml ]]; then
@@ -280,9 +279,9 @@ runtime-config|rc)
 
   if [[ "${do_netop}" == "true" || "${do_sysop}" == "true" ]]; then
     BOSH_ENVIRONMENT=$BOSH_URL \
-    BOSH_CA_CERT=$(safe read $vault/ssl/ca:certificate) \
+    BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
     BOSH_CLIENT="admin" \
-    BOSH_CLIENT_SECRET="$(safe read ${vault}/users/admin:password)" \
+    BOSH_CLIENT_SECRET="$(safe read "${GENESIS_SECRETS_BASE}users/admin:password")" \
     bosh update-runtime-config <( (
       echo 'releases:'
       echo '  - name:    os-conf'
@@ -306,19 +305,19 @@ runtime-config|rc)
       echo '          users:'
       if [[ "${do_netop}" == "true" ]]; then
         echo '            - name: netop'
-        echo '              public_key: (( vault $VAULT_PREFIX "/op/net:public" ))'
+        echo '              public_key: (( vault $GENESIS_SECRETS_BASE "/op/net:public" ))'
       fi
       if [[ "${do_sysop}" == "true" ]]; then
         echo '            - name: sysop'
-        echo '              crypted_password: (( vault $VAULT_PREFIX "/op/sys:password-crypt-sha512" ))'
+        echo '              crypted_password: (( vault $GENESIS_SECRETS_BASE "/op/sys:password-crypt-sha512" ))'
       fi
-    ) | VAULT_PREFIX="$vault" spruce merge rc.yml - )
+    ) |  spruce merge rc.yml - )
 
   else
     BOSH_ENVIRONMENT=$BOSH_URL \
-    BOSH_CA_CERT=$(safe read $vault/ssl/ca:certificate) \
+    BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
     BOSH_CLIENT="admin" \
-    BOSH_CLIENT_SECRET="$(safe read ${vault}/users/admin:password)" \
+    BOSH_CLIENT_SECRET="$(safe read "${GENESIS_SECRETS_BASE}users/admin:password")" \
     bosh update-runtime-config <(
       spruce merge <(echo "addons:"
                      echo "  - name: genesis-local-users") \
@@ -333,7 +332,7 @@ ssh) # DO NOT LIST THIS IN 'list'...
   echo ; describe "#G{Accessing $(lookup params.env) BOSH director via SSH...}" ; echo
 
   touch .key                             ; chmod 0600 .key
-  safe read $vault/op/net:private > .key ; chmod 0400 .key
+  safe read "${GENESIS_SECRETS_BASE}op/net:private" > .key ; chmod 0400 .key
   trap "rm -f $PWD/.key" QUIT INT TERM EXIT
 
   ip=$(lookup params.static_ip)

--- a/hooks/addon
+++ b/hooks/addon
@@ -1,5 +1,14 @@
 #!/bin/bash
-set -eu
+set -u
+#Version check
+min_version="2.7.0"
+genesis_version="$(genesis -v 2>&1 | grep '^Genesis v' | sed -e 's/Genesis v\(.*\) (.*$/\1/')"
+if ! [[ "$genesis_version" =~ -dev$ ]] && ! new_enough "$genesis_version" "$min_version" ; then
+  describe >&2 "" "#R{[ERROR]} This kit needs Genesis $min_version.  Please upgrade before continuing" ""
+  exit 1
+fi
+set -e
+
 export BOSH_ENVIRONMENT=""
 export BOSH_CA_CERT=""
 export BOSH_CLIENT=""

--- a/hooks/addon
+++ b/hooks/addon
@@ -60,15 +60,16 @@ login() {
 }
 
 upload_stemcell() {
-  local url sha1 os="$1" cpi="$2" version="$3" fix="$4" data="$5"
-  read -r url sha1 <<< "$(echo "$data" | jq -r --arg v "$version" '.[] | select(.version == $v)| .regular | .url + " " + .sha1')"
+  local url sha1 os="$1" cpi="$2" version="$3" fix="$4" data="$5" type="$6"
+  read -r url sha1 <<< "$(jq -r --arg t "$type" --arg v "$version" '.[] | select(.version == $v)| to_entries[] | select(.key == $t).value  | .url + " " + .sha1' <<<"$data")"
+  [[ "$type" == "regular" ]] && type="full"
   describe "" \
-    "#G{Initiating upload of stemcell to the }#M{$GENESIS_ENVIRONMENT}#G{ BOSH Director:}" \
-    "  * CPI:     #C{$cpi}" \
-    "  * OS:      #C{$os}" \
-    "  * VERSION: #C{$version}" \
-    "  * URL:     #C{$url}" \
-    "  * SHA1:    #C{$sha1}" \
+    "#G{Initiating upload of }#C{$type}#G{ stemcell to the }#M{$GENESIS_ENVIRONMENT}#G{ BOSH Director:}" \
+    "  * CPI:     #c{$cpi}" \
+    "  * OS:      #c{$os}" \
+    "  * VERSION: #c{$version}" \
+    "  * URL:     #c{$url}" \
+    "  * SHA1:    #c{$sha1}" \
     ""
   BOSH_ENVIRONMENT=$BOSH_URL \
     BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
@@ -108,16 +109,17 @@ upload_stemcells() {
     exit 1
   fi
 
-  local fix="" os="ubuntu-xenial"
+  local fix="" os="ubuntu-xenial" type="regular" type_s="full"
   local stemcells
   declare -a versions
   versions=()
   while test $# -gt 0 ; do
     case "$1" in
-      --fix) fix=" --fix" ;;
-      --os)  os="$2"; shift;;
-      --*)   describe "#R{[ERROR]} Bad option $1" && exit 1 ;;
-      *)     if [[ "$1" =~ .*@.* ]]; then versions+=("$1"); else versions+=("$os@$1"); fi;;
+      --fix)   fix=" --fix" ;;
+      --os)    os="$2"; shift;;
+      --light) type=type_s="light";;
+      --*)     describe "#R{[ERROR]} Bad option $1" && exit 1 ;;
+      *)       if [[ "$1" =~ .*@.* ]]; then versions+=("$1"); else versions+=("$os@$1"); fi;;
     esac
     shift
   done
@@ -144,16 +146,16 @@ upload_stemcells() {
       pattern="$(echo "$req_version" | sed -e 's/\.latest$/\.[0-9]+/')"
       match="$( \
         echo "${stemcells_for_oses[$i]}" | \
-        jq --arg re "^$pattern\$" '.[] | select(.regular? and (.version|test($re)))' | \
+        jq --arg re "^$pattern\$" --arg t "$type" '.[] | select((.version|test($re)) and (.|keys|index($t)))' | \
         jq -Ms '.')"
       version="$(echo "$match" | jq -Mr '.[] | .version' | sort -n -t. -k1 -k2 -k3 -k4| tail -n1)"
       if [[ -z "$version" ]] ; then
-        describe "#R{[ERROR]} No version found matching $req_version for OS $req_os"
+        describe "#R{[ERROR]} No $type_s version found matching $req_version for OS $req_os"
       else
         if [[ "$version" != "$req_version" ]] ; then
           describe "Using best match to #C{$req_version}: #G{$version}"
         fi
-        upload_stemcell "$req_os" "$cpi" "$version" "$fix" "$match"
+        upload_stemcell "$req_os" "$cpi" "$version" "$fix" "$match" "$type"
       fi
     done
   else
@@ -236,6 +238,7 @@ The following addons are defined:
 
     --fix              upload the stemcell even if its already uploaded
     --os <str>         use the os <str> (defaults to ubuntu-xenial)
+    --light            use light stemcells instead of full ones
 
     <version>...       specify one or more versions of default or last
                        specified --os option

--- a/hooks/addon
+++ b/hooks/addon
@@ -31,13 +31,13 @@ setup_alias() {
   BOSH_ENVIRONMENT="$BOSH_URL" \
     BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
     BOSH_CLIENT="admin" \
-    BOSH_CLIENT_SECRET="$(safe read ${GENESIS_SECRETS_BASE}users/admin:password)" \
-    bosh alias-env --tty $GENESIS_ENVIRONMENT| grep -v '^User'
+    BOSH_CLIENT_SECRET="$(safe read "${GENESIS_SECRETS_BASE}users/admin:password")" \
+    bosh alias-env --tty "$GENESIS_ENVIRONMENT"| grep -v '^User'
 }
 
 is_logged_in() {
   local user
-  user="$(bosh -e $GENESIS_ENVIRONMENT env --json | jq -Mr ".Tables[0].Rows[0].user")"
+  user="$(bosh -e "$GENESIS_ENVIRONMENT" env --json | jq -Mr ".Tables[0].Rows[0].user")"
   if [[ "$user" == "null" || "$user" == "(not logged in)" ]] ; then
     return 1
   fi
@@ -51,17 +51,17 @@ is_logged_in() {
 
 login() {
   echo "Logging you in as user 'admin'..."
-  printf "%s\n%s\n" admin "$(safe read ${GENESIS_SECRETS_BASE}users/admin:password)" | \
+  printf "%s\n%s\n" admin "$(safe read "${GENESIS_SECRETS_BASE}users/admin:password")" | \
     BOSH_ENVIRONMENT="" \
     BOSH_CA_CERT="" \
     BOSH_CLIENT="" \
     BOSH_CLIENT_SECRET="" \
-    bosh -e $GENESIS_ENVIRONMENT login
+    bosh -e "$GENESIS_ENVIRONMENT" login
 }
 
 upload_stemcell() {
   local url sha1 os="$1" cpi="$2" version="$3" fix="$4" data="$5"
-  read url sha1 <<< "$(echo "$data" | jq -r --arg v "$version" '.[] | select(.version == $v)| .regular | .url + " " + .sha1')"
+  read -r url sha1 <<< "$(echo "$data" | jq -r --arg v "$version" '.[] | select(.version == $v)| .regular | .url + " " + .sha1')"
   describe "" \
     "#G{Initiating upload of stemcell to the }#M{$GENESIS_ENVIRONMENT}#G{ BOSH Director:}" \
     "  * CPI:     #C{$cpi}" \
@@ -71,10 +71,10 @@ upload_stemcell() {
     "  * SHA1:    #C{$sha1}" \
     ""
   BOSH_ENVIRONMENT=$BOSH_URL \
-    BOSH_CA_CERT=$(safe read ${GENESIS_SECRETS_BASE}ssl/ca:certificate) \
+    BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
     BOSH_CLIENT="admin" \
-    BOSH_CLIENT_SECRET="$(safe read ${GENESIS_SECRETS_BASE}users/admin:password)" \
-    bosh upload-stemcell${fix} --sha1 "$sha1" "$url"
+    BOSH_CLIENT_SECRET="$(safe read "${GENESIS_SECRETS_BASE}users/admin:password")" \
+    bosh "upload-stemcell${fix}" --sha1 "$sha1" "$url"
   return $?
 }
 
@@ -186,10 +186,10 @@ credhub_login() {
   command -v credhub > /dev/null 2>&1 || _bail "Command 'credhub' not found.  Please install from https://github.com/cloudfoundry-incubator/credhub-cli"
 
   # Update api target with correct ca's
-  command credhub api https://$(lookup params.static_ip):8844 --ca-cert <(safe read ${GENESIS_SECRETS_BASE}ssl/ca:certificate; safe read ${GENESIS_SECRETS_BASE}credhub/ca:certificate)
+  command credhub api "https://$(lookup params.static_ip):8844" --ca-cert <(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate"; safe read "${GENESIS_SECRETS_BASE}credhub/ca:certificate")
 
   # Login via stored password
-  command credhub login -u credhub-cli -p "$(safe read ${GENESIS_SECRETS_BASE}uaa/users/credhub-cli:password)"
+  command credhub login -u credhub-cli -p "$(safe read "${GENESIS_SECRETS_BASE}uaa/users/credhub-cli:password")"
   echo
   command credhub --version
   echo
@@ -203,12 +203,12 @@ vault_proxy_login() {
   echo
   ip="$(lookup params.static_ip)"
   proxy="${GENESIS_ENVIRONMENT}-proxy"
-  password="$(safe read ${GENESIS_SECRETS_BASE}uaa/users/credhub-admin:password)"
+  password="$(safe read "${GENESIS_SECRETS_BASE}uaa/users/credhub-admin:password")"
   export SAFE_TARGET=""
-  safe target https://$ip:8200 -k --no-strongbox $proxy
-  echo "credhub-admin:$password" | safe -T $proxy auth token
-  if safe -T $proxy set secret/handshake knock=knock >/dev/null 2>&1; then
-    if safe -T $proxy read secret/handshake >/dev/null 2>&1; then
+  safe target "https://$ip:8200" -k --no-strongbox "$proxy"
+  echo "credhub-admin:$password" | safe -T "$proxy" auth token
+  if safe -T "$proxy" set secret/handshake knock=knock >/dev/null 2>&1; then
+    if safe -T "$proxy" read secret/handshake >/dev/null 2>&1; then
       describe "" \
                "Successfully connected to Credhub Vault Proxy on #C{https://$ip:8200}" \
                "Target name is #C{$proxy}" \
@@ -347,10 +347,12 @@ runtime-config|rc)
       echo '          users:'
       if [[ "${do_netop}" == "true" ]]; then
         echo '            - name: netop'
+        # shellcheck disable=2016
         echo '              public_key: (( vault $GENESIS_SECRETS_BASE "/op/net:public" ))'
       fi
       if [[ "${do_sysop}" == "true" ]]; then
         echo '            - name: sysop'
+        # shellcheck disable=2016
         echo '              crypted_password: (( vault $GENESIS_SECRETS_BASE "/op/sys:password-crypt-sha512" ))'
       fi
     ) |  spruce merge rc.yml - )
@@ -375,6 +377,7 @@ ssh) # DO NOT LIST THIS IN 'list'...
 
   touch .key                             ; chmod 0600 .key
   safe read "${GENESIS_SECRETS_BASE}op/net:private" > .key ; chmod 0400 .key
+  # shellcheck disable=2064
   trap "rm -f $PWD/.key" QUIT INT TERM EXIT
 
   ip=$(lookup params.static_ip)

--- a/hooks/addon
+++ b/hooks/addon
@@ -16,7 +16,7 @@ BOSH_URL="https://$(lookup params.static_ip):25555"
 # let's override it, shall we?
 #
 bosh() {
-  command $GENESIS_BOSH_COMMAND "$@"
+  command "$GENESIS_BOSH_COMMAND" "$@"
 }
 
 setup_alias() {
@@ -233,7 +233,7 @@ login)
 
 logout)
   setup_alias >/dev/null
-  bosh -e $GENESIS_ENVIRONMENT logout
+  bosh -e "$GENESIS_ENVIRONMENT" logout
   ;;
 
 vault-proxy-login)
@@ -254,6 +254,7 @@ runtime-config|rc)
     "a 4096-bit RSA SSH key for authentication.  It can be used to perform" \
     "out-of-band, remote management of BOSH VMs when BOSH is misbehaving." \
     ""
+  do_netop=
   prompt_for do_netop boolean \
     "Enable the netop account? " -i
 
@@ -262,6 +263,7 @@ runtime-config|rc)
     "a randomized password, for console-based authentication.  This can be" \
     "handy in vSphere environments when network-based authentication breaks." \
     ""
+  do_sysop=
   prompt_for do_sysop boolean \
     "Enable the sysop account? " -i
 
@@ -276,7 +278,7 @@ runtime-config|rc)
     echo "--- {}" > rc.yml
   fi
 
-  if [[ "${do_netop}" == "true" || ${do_sysop} == "true" ]]; then
+  if [[ "${do_netop}" == "true" || "${do_sysop}" == "true" ]]; then
     BOSH_ENVIRONMENT=$BOSH_URL \
     BOSH_CA_CERT=$(safe read $vault/ssl/ca:certificate) \
     BOSH_CLIENT="admin" \
@@ -336,7 +338,7 @@ ssh) # DO NOT LIST THIS IN 'list'...
 
   ip=$(lookup params.static_ip)
   set -x
-  exec ssh netop@$ip -o StrictHostKeyChecking=no -i .key
+  exec ssh "netop@$ip" -o StrictHostKeyChecking=no -i .key
   ;;
 
 *)

--- a/hooks/check
+++ b/hooks/check
@@ -1,4 +1,13 @@
 #!/bin/bash
+set -u
+#Version check
+min_version="2.7.0"
+genesis_version="$(genesis -v 2>&1 | grep '^Genesis v' | sed -e 's/Genesis v\(.*\) (.*$/\1/')"
+if ! [[ "$genesis_version" =~ -dev$ ]] && ! new_enough "$genesis_version" "$min_version" ; then
+  describe >&2 "" "#R{[ERROR]} This kit needs Genesis $min_version.  Please upgrade before continuing" ""
+  exit 1
+fi
+set -e
 
 # Cloud Config checks
 ok=yes

--- a/hooks/check
+++ b/hooks/check
@@ -4,9 +4,9 @@
 ok=yes
 if [[ -n "$GENESIS_CLOUD_CONFIG" ]] ; then
   if ! want_feature proto; then
-    cloud_config_needs vm_type    $(lookup params.bosh_vm_type   large)
-    cloud_config_needs network    $(lookup params.bosh_network   bosh)
-    cloud_config_needs disk_type  $(lookup params.bosh_disk_pool bosh)
+    cloud_config_needs vm_type    "$(lookup params.bosh_vm_type   large)"
+    cloud_config_needs network    "$(lookup params.bosh_network   bosh)"
+    cloud_config_needs disk_type  "$(lookup params.bosh_disk_pool bosh)"
 
     if check_cloud_config ; then
       describe "  cloud-config [#G{OK}]"
@@ -31,32 +31,31 @@ fi
 
 ip=$(lookup params.static_ip)
 describe "  checking if our certificates match the director static ip ($ip)..."
-vault="secret/$GENESIS_VAULT_PREFIX"
 check_cert() {
   cert=$1 ; shift
-  if ! safe exists "$vault/$cert"; then
-    describe "    - $vault/$cert [#Y{MISSING}]"
+  if ! safe exists "${GENESIS_SECRETS_BASE}$cert"; then
+    describe "    - ${GENESIS_SECRETS_BASE}$cert [#Y{MISSING}]"
     ok=no
   else
-    if safe --quiet x509 validate "$vault/$cert" "$@" >/dev/null 2>&1; then
-      describe "    - $vault/$cert [#G{OK}]"
+    if safe --quiet x509 validate "${GENESIS_SECRETS_BASE}$cert" "$@" >/dev/null 2>&1; then
+      describe "    - ${GENESIS_SECRETS_BASE}$cert [#G{OK}]"
     else
-      describe "    - $vault/$cert [#R{INVALID}]"
-      safe x509 validate "$vault/$cert" "$@" >&1 | sed -e 's/^/      /';
+      describe "    - ${GENESIS_SECRETS_BASE}$cert [#R{INVALID}]"
+      safe x509 validate "${GENESIS_SECRETS_BASE}$cert" "$@" >&1 | sed -e 's/^/      /';
       ok=no
       echo
     fi
   fi
 }
-check_cert ssl/server          --for $ip
-check_cert ssl/mbus            --for $ip
-check_cert ssl/uaa             --for $ip
-check_cert ssl/uaa-sp          --for $ip
-check_cert credhub/server      --for $ip
-check_cert nats/server         --for $ip --for default.nats.bosh-internal
-check_cert nats/director       --for $ip --for default.director.bosh-internal
-check_cert nats/health/monitor --for $ip --for default.hm.bosh-internal
-check_cert blobstore/server    --for $ip
+check_cert ssl/server          --for "$ip"
+check_cert ssl/mbus            --for "$ip"
+check_cert ssl/uaa             --for "$ip"
+check_cert ssl/uaa-sp          --for "$ip"
+check_cert credhub/server      --for "$ip"
+check_cert nats/server         --for "$ip" --for default.nats.bosh-internal
+check_cert nats/director       --for "$ip" --for default.director.bosh-internal
+check_cert nats/health/monitor --for "$ip" --for default.hm.bosh-internal
+check_cert blobstore/server    --for "$ip"
 
 if [[ "$ok" = "yes" ]]; then
   describe "  environment files [#G{OK}]"

--- a/hooks/info
+++ b/hooks/info
@@ -1,5 +1,13 @@
 #!/bin/bash
-set -eu
+set -u
+#Version check
+min_version="2.7.0"
+genesis_version="$(genesis -v 2>&1 | grep '^Genesis v' | sed -e 's/Genesis v\(.*\) (.*$/\1/')"
+if ! [[ "$genesis_version" =~ -dev$ ]] && ! new_enough "$genesis_version" "$min_version" ; then
+  describe >&2 "" "#R{[ERROR]} This kit needs Genesis $min_version.  Please upgrade before continuing" ""
+  exit 1
+fi
+set -e
 
 export BOSH_ENVIRONMENT="$(exodus url)"
 [[ -n $BOSH_ENVIRONMENT ]] || "https://127.0.0.1:25555";

--- a/hooks/info
+++ b/hooks/info
@@ -1,20 +1,33 @@
 #!/bin/bash
 set -eu
-vault="secret/$GENESIS_VAULT_PREFIX"
 
-export BOSH_ENVIRONMENT=https://$(lookup params.static_ip 127.0.0.1):25555
-export BOSH_CA_CERT=$(safe read $vault/ssl/ca:certificate)
-export BOSH_CLIENT=admin
-export BOSH_CLIENT_SECRET=$(safe read $vault/users/admin:password)
+export BOSH_ENVIRONMENT="$(exodus url)"
+[[ -n $BOSH_ENVIRONMENT ]] || "https://127.0.0.1:25555";
+export BOSH_CA_CERT="$(exodus ca_cert)"
+export BOSH_CLIENT="$(exodus admin_username)"
+export BOSH_CLIENT_SECRET="$(exodus admin_password)"
 
-describe "ca certificate"
-         safe read $vault/ssl/ca:certificate
-    echo
     echo "bosh env"
          bosh env --tty | sed -e 's/^/  /';
     echo
-    echo
     echo "accessing bosh"
-describe "  bosh url: #C{$BOSH_ENVIRONMENT}"
-describe "  username: #M{$BOSH_CLIENT}"
-describe "  password: #G{$BOSH_CLIENT_SECRET}"
+describe "  bosh url: #C{$BOSH_ENVIRONMENT}" \
+         "  username: #M{$BOSH_CLIENT}" \
+         "  password: #G{$BOSH_CLIENT_SECRET}" \
+         "" \
+         "ca certificate" \
+         "$BOSH_CA_CERT"
+
+export BOSH_CREDHUB_URL="$(exodus credhub_url)"
+if [[ -n $BOSH_CREDHUB_URL ]] ; then
+    echo
+describe "This BOSH deployment has a Credhub on #C{$BOSH_CREDHUB_URL}" \
+         "Log into it using #M{genesis do $GENESIS_ENVIRONMENT -- credhub-login}"
+fi
+
+if [[ -n $(exodus has_vault_credhub_proxy) ]] ; then
+    echo
+describe "You can also access Credhub via #C{safe} using the vault-credhub-proxy." \
+         "Run #M{genesis do $GENESIS_ENVIRONMENT -- vault-proxy-login} to connect."
+fi
+echo

--- a/hooks/new
+++ b/hooks/new
@@ -1,5 +1,13 @@
 #!/bin/bash
-set -eu
+set -u
+#Version check
+min_version="2.7.0"
+genesis_version="$(genesis -v 2>&1 | grep '^Genesis v' | sed -e 's/Genesis v\(.*\) (.*$/\1/')"
+if ! [[ "$genesis_version" =~ -dev$ ]] && ! new_enough "$genesis_version" "$min_version" ; then
+  describe >&2 "" "#R{[ERROR]} This kit needs Genesis $min_version.  Please upgrade before continuing" ""
+  exit 1
+fi
+set -e
 
 isproto=
 prompt_for isproto boolean \

--- a/hooks/new
+++ b/hooks/new
@@ -51,12 +51,12 @@ aws)
 	aws_access_key=
 	prompt_for aws_access_key line \
 		'What is your AWS Access Key?'
-	prompt_for $GENESIS_VAULT_PREFIX/aws:secret_key secret-line \
+	prompt_for aws:secret_key secret-line \
 		'What is your AWS Secret Key?'
 	aws_default_sgs=
 	prompt_for aws_default_sgs multi-line \
 		'What security groups should the all deployed VMs be placed in?'
-	safe set --quiet secret/$GENESIS_VAULT_PREFIX/aws access_key="$aws_access_key"
+	safe set --quiet "${GENESIS_SECRETS_BASE}aws" access_key="$aws_access_key"
 
 	if [[ $isproto == 'true' ]]; then
 		aws_subnet=
@@ -96,9 +96,9 @@ vsphere)
 	vsphere_user=
 	prompt_for vsphere_user line \
 		'What username should BOSH use to authenticate with vCenter?'
-	prompt_for $GENESIS_VAULT_PREFIX/vsphere:password secret-line \
+	prompt_for vsphere:password secret-line \
 		'What is the password for the vCenter user?'
-	safe --quiet set secret/$GENESIS_VAULT_PREFIX/vsphere user="$vsphere_user" address="$vsphere_address"
+	safe --quiet set "${GENESIS_SECRETS_BASE}vsphere" user="$vsphere_user" address="$vsphere_address"
 
 	vsphere_dc=
 	prompt_for vsphere_dc line \
@@ -138,7 +138,7 @@ google)
 	google_json_key=
 	prompt_for google_json_key block \
 		'What are your GCP credentials (generally supplied as a JSON block)?'
-	safe set --quiet secret/$GENESIS_VAULT_PREFIX/google json_key="$google_json_key"
+	safe set --quiet "${GENESIS_SECRETS_BASE}google" json_key="$google_json_key"
 
 	if [[ $isproto == 'true' ]]; then
 		google_net=
@@ -160,7 +160,7 @@ azure)
 	azure_client_id=
 	prompt_for azure_client_id line \
 		'What is your Azure Client ID?'
-	prompt_for $GENESIS_VAULT_PREFIX/azure:client_secret secret-line \
+	prompt_for azure:client_secret secret-line \
 		'What is your Azure Client Secret?'
 	azure_tenant_id=
 	prompt_for azure_tenant_id line \
@@ -171,9 +171,10 @@ azure)
 	azure_resource_group=
 	prompt_for azure_resource_group line \
 		'What Azure Resource Group will BOSH be deploying VMs into?'
-	safe --quiet set secret/$GENESIS_VAULT_PREFIX/azure client_id="$azure_client_id" \
-	                                      tenant_id="$azure_tenant_id" \
-	                                      subscription_id="$azure_subscription_id"
+	safe --quiet set "${GENESIS_SECRETS_BASE}azure" \
+		client_id="$azure_client_id" \
+		tenant_id="$azure_tenant_id" \
+		subscription_id="$azure_subscription_id"
 
 	azure_default_sg=
 	prompt_for azure_default_sg line \
@@ -196,7 +197,7 @@ openstack)
 	openstack_user=
 	prompt_for openstack_user line \
 		'What username will be used to authenticate with OpenStack?'
-	prompt_for $GENESIS_VAULT_PREFIX/openstack/creds:password secret-line \
+	prompt_for openstack/creds:password secret-line \
 		'What password will be used to authenticate with OpenStack?'
 	openstack_domain=
 	prompt_for openstack_domain line \
@@ -204,9 +205,10 @@ openstack)
 	openstack_project=
 	prompt_for openstack_project line \
 		'What OpenStack Project will BOSH be deployed in?'
-	safe set --quiet secret/$GENESIS_VAULT_PREFIX/openstack/creds username="$openstack_user" \
-	                                                domain="$openstack_domain" \
-	                                                project="$openstack_project"
+	safe set --quiet "${GENESIS_SECRETS_BASE}openstack/creds" \
+		username="$openstack_user" \
+		domain="$openstack_domain" \
+		project="$openstack_project"
 
 	openstack_region=
 	prompt_for openstack_region line \
@@ -244,10 +246,10 @@ if [[ $isproto == 'true' ]]; then
 	echo "    - proto"
 fi
 
+genesis_config_block
+
 echo
 echo "params:"
-echo "  env:   $GENESIS_ENVIRONMENT"
-echo
 
 if [[ $isproto == 'true' ]]; then
 	echo "  # These properties definte the host-level networking for a proto-BOSH."
@@ -420,8 +422,4 @@ openstack)
 esac
 ) > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"
 
-prompt_for edit boolean \
-	'Would you like to edit the environment file?'
-if [[ $edit = 'true' ]]; then
-	exec ${EDITOR:-vim} $GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
-fi
+offer_environment_editor

--- a/hooks/new
+++ b/hooks/new
@@ -1,30 +1,37 @@
 #!/bin/bash
 set -eu
 
+isproto=
 prompt_for isproto boolean \
 	'Is this a proto-BOSH director?'
 
+ip=
 prompt_for ip line \
 	'What static IP do you want to deploy this BOSH director on?' \
 	--validation ip
 
 if [[ $isproto == 'true' ]]; then
+	proto_net=
 	prompt_for proto_net line \
 		'What network should this BOSH director exist in (in CIDR notation)?'
+	proto_gw=
 	prompt_for proto_gw line \
 		'What default gateway (IP address) should this BOSH director use?' \
 		--validation ip
 
+	proto_dns=
 	prompt_for proto_dns multi-line \
 		'What DNS servers should BOSH use?'
 
 else
+	parent_bosh=
 	prompt_for parent_bosh line \
 		'What is the alias of the BOSH director you want to use to deploy *this* BOSH director?'
 fi
 
 ###########################################################################
 
+iaas=
 prompt_for iaas select \
 	'What IaaS will this BOSH director orchestrate?' \
 	-o '[vsphere]   VMWare vSphere'        \
@@ -37,21 +44,26 @@ prompt_for iaas select \
 
 case $iaas in
 aws)
+	aws_region=
 	prompt_for aws_region line \
 		'What AWS region would you like to deploy to?'
 
+	aws_access_key=
 	prompt_for aws_access_key line \
 		'What is your AWS Access Key?'
 	prompt_for $GENESIS_VAULT_PREFIX/aws:secret_key secret-line \
 		'What is your AWS Secret Key?'
+	aws_default_sgs=
 	prompt_for aws_default_sgs multi-line \
 		'What security groups should the all deployed VMs be placed in?'
 	safe set --quiet secret/$GENESIS_VAULT_PREFIX/aws access_key="$aws_access_key"
 
 	if [[ $isproto == 'true' ]]; then
+		aws_subnet=
 		prompt_for aws_subnet line \
 			'What is the ID of the AWS subnet you want to deploy to?'
 
+		aws_bosh_sgs=
 		prompt_for aws_bosh_sgs multi-line \
 			'What security groups should the BOSH Director VM be in?'
 	fi
@@ -77,27 +89,35 @@ EOF
 	;;
 
 vsphere)
+	vsphere_address=
 	prompt_for vsphere_address line \
 		'What is the IP address of your VMWare vCenter Server Appliance?' \
 		--validation ip
+	vsphere_user=
 	prompt_for vsphere_user line \
 		'What username should BOSH use to authenticate with vCenter?'
 	prompt_for $GENESIS_VAULT_PREFIX/vsphere:password secret-line \
 		'What is the password for the vCenter user?'
 	safe --quiet set secret/$GENESIS_VAULT_PREFIX/vsphere user="$vsphere_user" address="$vsphere_address"
 
+	vsphere_dc=
 	prompt_for vsphere_dc line \
 		'What vCenter data center do you want to BOSH to deploy to?'
+	vsphere_cluster=
 	prompt_for vsphere_cluster line \
 		'What vCenter cluster do you want BOSH to deploy to?'
+	vsphere_resource_pool=
 	prompt_for vsphere_resource_pool line --default none \
 		'What vCenter resource pool (if any) do you want BOSH to deploy to?'
 
+	vsphere_ephemerals=
 	prompt_for vsphere_ephemerals multi-line -m 1 \
 		'What data stores do you wish to use for ephemeral (OS) disks?'
+	same_datastores=
 	prompt_for same_datastores boolean \
 		'Do you wish to use these same data stores for persistent (data) disks?'
 	if [[ $same_datastores == 'false' ]]; then
+		vsphere_persistents=
 		prompt_for vsphere_persistents multi-line -m 1 \
 			'What data stores do you wish to use for persistent (data) disks?'
 	else
@@ -105,83 +125,107 @@ vsphere)
 	fi
 
 	if [[ $isproto == 'true' ]]; then
+		vsphere_net=
 		prompt_for vsphere_net line \
 			'What is the name of the VM network in vCenter to deploy BOSH to?'
 	fi
 	;;
 
 google)
+	google_project_id=
 	prompt_for google_project_id line \
 		'What is your GCP project ID?'
+	google_json_key=
 	prompt_for google_json_key block \
 		'What are your GCP credentials (generally supplied as a JSON block)?'
 	safe set --quiet secret/$GENESIS_VAULT_PREFIX/google json_key="$google_json_key"
 
 	if [[ $isproto == 'true' ]]; then
+		google_net=
 		prompt_for google_net line \
 			'What is your GCP network name?'
+		google_subnet=
 		prompt_for google_subnet line \
 			'What is your GCP subnetwork name?'
+		google_azs=
 		prompt_for google_azs line \
 			'What availability zone do you want the BOSH VM to reside in?'
+		google_tags=
 		prompt_for google_tags multi-line \
 			'What tags would you like to be set on the BOSH VM?'
 	fi
 	;;
 
 azure)
+	azure_client_id=
 	prompt_for azure_client_id line \
 		'What is your Azure Client ID?'
 	prompt_for $GENESIS_VAULT_PREFIX/azure:client_secret secret-line \
 		'What is your Azure Client Secret?'
+	azure_tenant_id=
 	prompt_for azure_tenant_id line \
 		'What is your Azure Tenant ID?'
+	azure_subscription_id=
 	prompt_for azure_subscription_id line \
 		'What is your Azure Subscription ID?'
+	azure_resource_group=
 	prompt_for azure_resource_group line \
 		'What Azure Resource Group will BOSH be deploying VMs into?'
 	safe --quiet set secret/$GENESIS_VAULT_PREFIX/azure client_id="$azure_client_id" \
 	                                      tenant_id="$azure_tenant_id" \
 	                                      subscription_id="$azure_subscription_id"
 
+	azure_default_sg=
 	prompt_for azure_default_sg line \
 		'What security group should be used as the BOSH default security group?'
 
 	if [[ $isproto == "true" ]]; then
+		azure_vnet=
 		prompt_for azure_vnet line \
 			'What is the name of your Azure Virtual Network?'
+		azure_subnet_name=
 		prompt_for azure_subnet_name line \
 			'What is the name of the Azure subnet that the BOSH will be placed in?'
 	fi
 	;;
 
 openstack)
+	openstack_auth_url=
 	prompt_for openstack_auth_url line \
 		'What is the Auth URL of your OpenStack cluster?'
+	openstack_user=
 	prompt_for openstack_user line \
 		'What username will be used to authenticate with OpenStack?'
 	prompt_for $GENESIS_VAULT_PREFIX/openstack/creds:password secret-line \
 		'What password will be used to authenticate with OpenStack?'
+	openstack_domain=
 	prompt_for openstack_domain line \
 		'What OpenStack Domain will BOSH be deployed in?'
+	openstack_project=
 	prompt_for openstack_project line \
 		'What OpenStack Project will BOSH be deployed in?'
 	safe set --quiet secret/$GENESIS_VAULT_PREFIX/openstack/creds username="$openstack_user" \
 	                                                domain="$openstack_domain" \
 	                                                project="$openstack_project"
 
+	openstack_region=
 	prompt_for openstack_region line \
 		'What OpenStack Region is BOSH being deployed to?'
+	openstack_ssh_key=
 	prompt_for openstack_ssh_key line \
 		'What is the name of the OpenStack SSH key that should be used to enable SSH access to BOSH-deployed VMs?'
+	openstack_default_sgs=
 	prompt_for openstack_default_sgs multi-line \
 		'What default security groups should be applied to VMs created by BOSH?'
 
 	if [[ $isproto == "true" ]]; then
+		openstack_network_id=
 		prompt_for openstack_network_id line \
 			'What is the UUID of the OpenStack network that BOSH will be placed in?'
+		openstack_flavor=
 		prompt_for openstack_flavor line \
 			'What OpenStack flavor (instance type) should the BOSH VM use?'
+		openstack_az=
 		prompt_for openstack_az line \
 			'What AZ will the BOSH Director be placed in?'
 	fi
@@ -214,7 +258,7 @@ if [[ $isproto == 'true' ]]; then
 	echo "  subnet_addr:     $proto_net"
 	echo "  default_gateway: $proto_gw"
 	echo "  dns:"
-	for dns in ${proto_dns[@]}; do
+	for dns in "${proto_dns[@]}"; do
 		echo "    - $dns"
 	done
 else
@@ -237,7 +281,7 @@ aws)
 	echo "  #"
 	echo "  aws_region: $aws_region"
 	echo "  aws_default_sgs:"
-	for sg in ${aws_default_sgs[@]}; do
+	for sg in "${aws_default_sgs[@]}"; do
 		echo "    - $sg"
 	done
 	echo
@@ -248,7 +292,7 @@ aws)
 		echo "  #"
 		echo "  aws_subnet_id: $aws_subnet"
 		echo "  aws_security_groups:"
-		for sg in ${aws_bosh_sgs[@]}; do
+		for sg in "${aws_bosh_sgs[@]}"; do
 			echo "    - $sg"
 		done
 		echo
@@ -275,7 +319,7 @@ vsphere)
 	echo "  # and temporary work areas, on any of theses data stores"
 	echo "  #"
 	echo "  vsphere_ephemeral_datastores:"
-	for ds in ${vsphere_ephemerals[@]}; do
+	for ds in "${vsphere_ephemerals[@]}"; do
 		echo "    - $ds"
 	done
 	echo
@@ -284,7 +328,7 @@ vsphere)
 	echo "  # on any of theses data stores"
 	echo "  #"
 	echo "  vsphere_persistent_datastores:"
-	for ds in ${vsphere_persistents[@]}; do
+	for ds in "${vsphere_persistents[@]}"; do
 		echo "    - $ds"
 	done
 	echo
@@ -315,7 +359,7 @@ google)
 		echo "  google_subnetwork_name:   $google_subnet"
 		echo "  google_availability_zone: $google_azs"
 		echo "  google_tags:"
-		for t in ${google_tags[@]}; do
+		for t in "${google_tags[@]}"; do
 			echo "    - $t"
 		done
 		echo
@@ -357,7 +401,7 @@ openstack)
 	echo "  openstack_region:   $openstack_region"
 	echo "  openstack_ssh_key:  $openstack_ssh_key"
 	echo "  openstack_default_security_groups:"
-	for sg in ${openstack_default_sgs[@]}; do
+	for sg in "${openstack_default_sgs[@]}"; do
 		echo "    - $sg"
 	done
 	echo
@@ -374,7 +418,7 @@ openstack)
 	;;
 
 esac
-) >$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
+) > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"
 
 prompt_for edit boolean \
 	'Would you like to edit the environment file?'

--- a/hooks/post-deploy
+++ b/hooks/post-deploy
@@ -3,25 +3,39 @@ set -eu
 
 if [[ $GENESIS_DEPLOY_RC == 0 ]]; then
 
-      echo; echo;
-  describe "#M{$GENESIS_ENVIRONMENT} BOSH Director deployed!"
-      echo
-      echo "For details about the deployment, run"
-      echo
-  describe "  #G{genesis info $GENESIS_ENVIRONMENT}"
-      echo
-      echo "To set up a named alias for this director, run"
-      echo
-  describe "  #G{genesis do $GENESIS_ENVIRONMENT -- alias}"
-      echo
-      echo "To log into the BOSH director, as the admin user, run"
-      echo
-  describe "  #G{genesis do $GENESIS_ENVIRONMENT -- login}"
-      echo
-      echo "If this is a new BOSH director, you can upload"
-      echo "stemcells by running"
-      echo
-  describe "  #G{genesis do $GENESIS_ENVIRONMENT -- upload-stemcells}"
-      echo
+  describe "" \
+           "#M{$GENESIS_ENVIRONMENT} BOSH Director deployed!" \
+           "" \
+           "For details about the deployment, run" \
+           "" \
+           "  #G{genesis info $GENESIS_ENVIRONMENT}" \
+           "" \
+           "To set up a named alias for this director, run" \
+           "" \
+           "  #G{genesis do $GENESIS_ENVIRONMENT -- alias}" \
+           "" \
+           "To log into the BOSH director, as the admin user, run" \
+           "" \
+           "  #G{genesis do $GENESIS_ENVIRONMENT -- login}" \
+           "" \
+           "If this is a new BOSH director, you can upload" \
+           "stemcells by running" \
+           "" \
+           "  #G{genesis do $GENESIS_ENVIRONMENT -- upload-stemcells}" \
+           "" \
+           "" \
+           "This BOSH director provides a Credhub secrets store." \
+           "You can log into it by running" \
+           "" \
+           "  #G{genesis do $GENESIS_ENVIRONMENT -- credhub-login}" \
+           ""
+
+  if want_feature vault-credhub-proxy ; then
+  describe "It also provides a vault-credhub-proxy server, which" \
+           "allows you to access credhub via #C{safe}.  To login, run" \
+           "" \
+           "   #G{genesis do $GENESIS_ENVIRONMENT -- vault-proxy-login}" \
+           ""
+  fi
 
 fi

--- a/kit.yml
+++ b/kit.yml
@@ -9,52 +9,56 @@ genesis_version_min: 2.6.0
 certificates:
   base:
     ssl:
-      ca: { valid_for: 1y }
+      ca:
+        valid_for: ${params.ca_validity_period}
       server:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - ${params.static_ip}
       mbus:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - ${params.static_ip}
       uaa:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - ${params.static_ip}
       uaa-sp:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - ${params.static_ip}
 
     blobstore:
-      ca: { valid_for: 1y }
+      ca:
+        valid_for: ${params.ca_validity_period}
       server:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - ${params.static_ip}
 
     credhub:
-      ca: { valid_for: 1y }
+      ca:
+        valid_for: ${params.ca_validity_period}
       server:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - ${params.static_ip}
 
     nats:
-      ca: { valid_for: 1y }
+      ca:
+        valid_for: ${params.ca_validity_period}
       server:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - default.nats.bosh-internal
         - ${params.static_ip}
       director:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - default.director.bosh-internal
         - ${params.static_ip}
       health/monitor:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         names:
         - default.hm.bosh-internal
         - ${params.static_ip}
@@ -62,7 +66,7 @@ certificates:
   vault-credhub-proxy:
     vault-proxy_tls:
       server:
-        valid_for: 1y
+        valid_for: ${params.cert_validity_period}
         signed_by: credhub/ca
         names:
         - ${params.static_ip}

--- a/kit.yml
+++ b/kit.yml
@@ -7,7 +7,7 @@ docs:    https://github.com/genesis-community/bosh-genesis-kit
 code:    https://github.com/genesis-community/bosh-genesis-kit
 version: 1.10.0
 
-genesis_version_min: 2.7.0-rc4
+genesis_version_min: 2.7.0
 
 certificates:
   base:

--- a/kit.yml
+++ b/kit.yml
@@ -1,10 +1,13 @@
 ---
-name:   bosh
-author: James Hunt <jhunt@starkandwayne.com>
-docs:   https://github.com/genesis-community/bosh-genesis-kit
-code:   https://github.com/genesis-community/bosh-genesis-kit
+name:    bosh
+authors: [ James Hunt <jhunt@starkandwayne.com>,
+           Troy Liebel <tliebel@starkandwayne.com>,
+           Dennis Bell <dbell@starkandwayne.com> ]
+docs:    https://github.com/genesis-community/bosh-genesis-kit
+code:    https://github.com/genesis-community/bosh-genesis-kit
+version: 1.10.0
 
-genesis_version_min: 2.6.0
+genesis_version_min: 2.7.0-rc4
 
 certificates:
   base:

--- a/manifests/addons/vault-credhub-proxy.yml
+++ b/manifests/addons/vault-credhub-proxy.yml
@@ -3,6 +3,9 @@ meta:
     - (( vault meta.vault "/credhub/ca:certificate" ))
     - (( vault meta.vault "/ssl/ca:certificate" ))
 
+exodus:
+  has_vault_credhub_proxy: 1
+
 releases:
   - name: vault-credhub-proxy
     .:    (( inject meta.releases.vault-credhub-proxy ))

--- a/manifests/bosh/bosh.yml
+++ b/manifests/bosh/bosh.yml
@@ -8,6 +8,9 @@ params:
   bosh_disk_pool: bosh
   bosh_vm_type:   large
 
+  ca_validity_period:   5y
+  cert_validity_period: 1y
+
   session_timeout: 1 # In days
 
   ntp: [ 0.pool.ntp.org, 1.pool.ntp.org ]

--- a/manifests/bosh/bosh.yml
+++ b/manifests/bosh/bosh.yml
@@ -24,11 +24,6 @@ exodus:
   admin_username: admin
   admin_password: (( vault meta.vault "/users/admin:password" ))
 
-  credhub_url:      (( concat "https://" params.static_ip ":8844" ))
-  credhub_ca_cert:  (( vault meta.vault "/credhub/ca:certificate" ))
-  credhub_username: credhub-cli
-  credhub_password: (( vault meta.vault "/uaa/users/credhub-cli:password" ))
-
 name: (( grab params.name ))
 
 releases:

--- a/manifests/bosh/credhub.yml
+++ b/manifests/bosh/credhub.yml
@@ -1,4 +1,10 @@
 ---
+exodus:
+  credhub_url:      (( concat "https://" params.static_ip ":8844" ))
+  credhub_ca_cert:  (( vault meta.vault "/credhub/ca:certificate" ))
+  credhub_username: credhub-cli
+  credhub_password: (( vault meta.vault "/uaa/users/credhub-cli:password" ))
+
 instance_groups:
   - name: bosh
     jobs:


### PR DESCRIPTION
# Genesis v2.7.0 Improvements

This updates the kit to be compatible with the soon-to-be-released Genesis v2.7.0. It improves handling of secrets, adds support for dynamic x509 validity periods, and ensures Genesis is updated enough to support the hook scripts (due to requiring variables provided in v2.7.0)

It also contains the following improvements:

* Refactored `upload-stemcells` to handle alternate OSs and light stemcells (Fixes #70 and #47, #48)
* Better information provided by `genesis info` and `genesis deploy` regarding credhub and vault-credhub-proxy availabilty
* Generally improves the coding standard of the bash hook scripts (compliance with shellcheck)