### PR TITLE
[workaround issue #63] remove empty newlines from rc.yml

### DIFF
--- a/hooks/addon
+++ b/hooks/addon
@@ -318,7 +318,7 @@ runtime-config|rc)
    BOSH_CA_CERT=$(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate") \
    BOSH_CLIENT="admin" \
    BOSH_CLIENT_SECRET="$(safe read "${GENESIS_SECRETS_BASE}users/admin:password")" \
-   bosh runtime-config) | sed -e 's/\s+//' > rc.yml
+   bosh runtime-config) | sed -e 's/\s+//' | sed '/^$/d' > rc.yml
 
   if [[ ! -s rc.yml ]]; then
     echo "--- {}" > rc.yml


### PR DESCRIPTION
The issue is caused by the fact that _bosh cli_ returns a (not so easily noticeable) **newline character** when _runtime-config_ is empty. As this makes the temp _rc.yml_ file non-empty (1 byte), the kit's addon script cannot insert a valid empty YAML `--- {}` into _rc.yml_. This eventually leads to _spruce_ complaining (and for a very good reason).
As stated [here](https://github.com/geofffranks/spruce/issues/256), _spruce_ does properly handle valid YAML files including those that have empty content.
The suggested workaround aims to remove useless empty newlines from _runtime-config_ which gets temporarily saved to _rc.yml_ by piping original output through an additional _sed_ command.
As @jhunt suggested, the fix is expected to come with _spruce_ itself being able to deal with empty YAMLs.