### PR TITLE
Bump AWS cpi to 82.

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,32 @@
+# Software Updates
+
+- Updated AWS CPI to 82 from 81, was missed in 1.10.0.
+
+# BOSH Director Components
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ |
+| bosh | [270.12.0](https://github.com/cloudfoundry/bosh/releases/tag/v270.12.0) | 26 February 2020 |
+| bpm | [1.1.7](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.7) | 10 February 2020 |
+| uaa | [74.15.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v74.15.0) | 2 March 2020 |
+| credhub | [2.5.11](https://github.com/pivotal-cf/credhub-release/releases/tag/2.5.11) | 30 January 2020 |
+
+# Cloud Provider Interfaces
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ |
+| bosh-azure-cpi | [37.2.0](https://github.com/cloudfoundry/bosh-azure-cpi-release/releases/tag/v37.2.0) | 23 January 2020 |
+| bosh-google-cpi | [30.0.0](https://github.com/cloudfoundry/bosh-google-cpi-release/releases/tag/v30.0.0) | 12 December 2019 |
+| bosh-aws-cpi | [82](https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v82) | 6 March 2020 |
+| bosh-vsphere-cpi | [53.0.9](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/releases/tag/v53.0.9) | 6 March 2020 |
+| bosh-openstack-cpi | [44](https://github.com/cloudfoundry/bosh-openstack-cpi-release/releases/tag/v44) | 20 November 2019 |
+| bosh-warden-cpi | [41](https://github.com/cppforlife/bosh-warden-cpi-release/releases/tag/v41) | 18 July 2018 |
+| garden-runc | [1.19.10](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.19.10) | 22 January 2020 |
+
+# Extras
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ |
+| port-forwarding | [6](https://github.com/cloudfoundry-community/port-forwarding-boshrelease/releases/tag/v6) | 26 July 2016 |
+| os-conf | [21.0.0](https://github.com/cloudfoundry/os-conf-release/releases/tag/v21.0.0) | 4 September 2019 |
+| vault-credhub-proxy | [1.1.9](https://github.com/starkandwayne/vault-credhub-proxy-release/releases/tag/v1.1.9) | 16 April 2020 |

--- a/manifests/versions.yml
+++ b/manifests/versions.yml
@@ -42,8 +42,8 @@ meta:
 
 
     - name:    bosh-aws-cpi
-      version: "81"
-      sha1:    a70c68afc3733a4c1f486e3e526dac9d5edaea21
+      version: "82"
+      sha1:    1a4826469e715f5595de38a15df7b7f511fbfe85
       url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=" meta.releases.bosh-aws-cpi.version ))
 
     - name:    bosh-azure-cpi


### PR DESCRIPTION
This software update was mistakenly missed in 1.10.0. 
82 is still the most recent release as of now. 