### PR TITLE
add iam instance profile feature

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -139,7 +139,8 @@ The following secrets will be pulled from the vault:
   - **Access Key** - The Amazon Access Key ID (and its counterpart
     secret key) for use when dealing with the Amazon Web Services
     API.  This is the single most important credential.
-    It is stored in the vault, at `secret/$env/bosh/aws`
+    It is stored in the vault, at `secret/$env/bosh/aws`. This is not required
+    if you are using IAM Instance Profiles (see below).
 
 If you also activate the `proto` feature, you will get a
 _Proto-BOSH_, which is deplyed via `bosh create-env`.  That
@@ -158,6 +159,20 @@ requires a bit more configuration:
 
   - `aws_disk_type` - What type of disk to use for the proto-BOSH
     director's persistent storage.  Defaults to `gp2`.
+
+If you are using AWS IAM Instance Profiles instead of access keys, activate
+the `iam_instance_profile` feature. In this case, you will no longer need an
+access key pair. If this deployment is a Proto-BOSH, then will need to provide
+the following param:
+
+  - `aws_proto_iam_instance_profile` - The instance profile to associate with
+    the Proto-BOSH director you are deploying.
+
+Keep in mind that if this is a Proto-BOSH deployment, it will cause both the
+create-env temporary BOSH and the deployed Proto-BOSH to use IAM Instance
+Profile. This means that the bastion host you are deploying from will need to
+have an IAM Instance Profile associated with it already. If you need the
+bastion host to use access keys, that will require manual overrides.
 
 ## Deploying to Microsoft Azure
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -7,7 +7,8 @@ validate_features aws azure google openstack vsphere warden \
                   aws-cpi azure-cpi google-cpi openstack-cpi vsphere-cpi warden-cpi \
                   aws-init azure-init google-init openstack-init vsphere-init bosh-init \
                   proxy credhub shield bosh proto skip-op-users registry vault-credhub-proxy \
-                  external-db external-db-ca external-db-no-tls s3-blobstore
+                  external-db external-db-ca external-db-no-tls s3-blobstore \
+                  iam-instance-profile
 
 #
 # We always start out with the skeleton of a BOSH deployment,
@@ -66,6 +67,24 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
       merge+=(
         manifests/addons/vault-credhub-proxy.yml \
       )
+    fi
+
+    if want_feature iam-instance-profile; then
+      if [[ $want != "aws" ]]; then
+        printf >&2 "Cannot use IAM instance profiles if not deploying to AWS"
+        exit 2
+      fi
+
+      merge+=(
+        manifests/addons/iam-profile.yml
+      )
+
+      if want_feature proto; then
+        merge+=(
+          manifests/addons/proto-iam-profile.yml
+        )    
+      fi
+
     fi
 
     if want_feature external-db; then

--- a/hooks/new
+++ b/hooks/new
@@ -44,22 +44,42 @@ prompt_for iaas select \
 	-o '[openstack] OpenStack' \
 	-o '[warden]    BOSH Warden'
 
-
+features=()
 case $iaas in
 aws)
 	aws_region=
 	prompt_for aws_region line \
 		'What AWS region would you like to deploy to?'
 
-	aws_access_key=
-	prompt_for aws_access_key line \
-		'What is your AWS Access Key?'
-	prompt_for aws:secret_key secret-line \
-		'What is your AWS Secret Key?'
+
+	aws_iam_profile_name=
+	aws_auth_method=
+	prompt_for aws_auth_method select \
+	  'How will this BOSH director authenticate to AWS?' \
+		-o '[access_key] Access/Secret Keypair' \
+		-o '[profile]    IAM Instance Profile'  
+	
+	if [[ $aws_auth_method == 'access_key' ]]; then
+		aws_access_key=
+		prompt_for aws_access_key line \
+			'What is your AWS Access Key?'
+		prompt_for aws:secret_key secret-line \
+			'What is your AWS Secret Key?'
+		safe set --quiet "${GENESIS_SECRETS_BASE}aws" access_key="$aws_access_key"
+  else
+	  features+=(
+			"iam-instance-profile"
+		) 
+
+		if [[ $isproto == 'true' ]]; then
+			prompt_for aws_iam_profile_name line \
+				'What AWS IAM instance profile should the Proto-BOSH VM have associated with it?'
+		fi
+	fi
+
 	aws_default_sgs=
 	prompt_for aws_default_sgs multi-line \
 		'What security groups should the all deployed VMs be placed in?'
-	safe set --quiet "${GENESIS_SECRETS_BASE}aws" access_key="$aws_access_key"
 
 	if [[ $isproto == 'true' ]]; then
 		aws_subnet=
@@ -248,6 +268,9 @@ echo "    - $iaas"
 if [[ $isproto == 'true' ]]; then
 	echo "    - proto"
 fi
+for feature in "${features[@]}"; do
+	echo "    - ${feature}"
+done
 
 genesis_config_block
 
@@ -295,11 +318,15 @@ aws)
 		echo "  # and VM/AMI configuration from their parent BOSH cloud-config."
 		echo "  #"
 		echo "  aws_subnet_id: $aws_subnet"
+
 		echo "  aws_security_groups:"
 		for sg in "${aws_bosh_sgs[@]}"; do
 			echo "    - $sg"
 		done
 		echo
+		if [[ -n $aws_iam_profile_name ]]; then
+			echo "  aws_proto_iam_instance_profile: ${aws_iam_profile_name}"
+		fi
 	fi
 	;;
 

--- a/kit.yml
+++ b/kit.yml
@@ -151,25 +151,19 @@ credentials:
   openstack-cpi: *openstack
 
 provided:
-  aws: &provided_aws
-    aws:
-      keys:
-        secret_key:
-          prompt:    AWS Secret Key
-        access_key:
-          sensitive: false
-          prompt:    AWS Access Key
-
-  aws-cpi: *provided_aws
-
-  s3-blobstore:
-    blobstore/s3:
-      keys:
-        access_key:
-          sensitive: false
-          prompt:    AWS Blobstore Access Key
-        secret_key:
-          prompt:    AWS Blobstore Secret Key
+# if the user provides iam-instance-profile, then we would not want genesis to
+# force the user to have access and secret keys. Until there is a feature that
+# allows this functionality, just don't enforce these keys for now.
+#
+#  aws: &provided_aws
+#    aws:
+#      keys:
+#        secret_key:
+#          prompt:    AWS Secret Key
+#        access_key:
+#          sensitive: false
+#          prompt:    AWS Access Key
+#  aws-cpi: *provided_aws
 
   vsphere: &provided_vsphere
     vsphere:

--- a/kit.yml
+++ b/kit.yml
@@ -165,6 +165,15 @@ provided:
 #          prompt:    AWS Access Key
 #  aws-cpi: *provided_aws
 
+  s3-blobstore:
+    blobstore/s3:
+      keys:
+        access_key:
+          sensitive: false
+          prompt:    AWS Blobstore Access Key
+        secret_key:
+          prompt:    AWS Blobstore Secret Key
+
   vsphere: &provided_vsphere
     vsphere:
       keys:

--- a/manifests/addons/iam-profile.yml
+++ b/manifests/addons/iam-profile.yml
@@ -1,0 +1,10 @@
+---
+- type: remove
+  path: /instance_groups/name=bosh/properties/aws/access_key_id
+
+- type: remove
+  path: /instance_groups/name=bosh/properties/aws/secret_access_key
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/aws/credentials_source?
+  value: env_or_profile

--- a/manifests/addons/proto-iam-profile.yml
+++ b/manifests/addons/proto-iam-profile.yml
@@ -1,0 +1,7 @@
+params:
+  aws_proto_iam_instance_profile: (( param "Please provide the IAM instance profile to associate with the proto-BOSH director VM"))
+
+resource_pools:
+- name: (( grab params.bosh_vm_type ))
+  cloud_properties:
+    iam_instance_profile: (( grab params.aws_proto_iam_instance_profile ))


### PR DESCRIPTION
This adds a feature to use IAM Instance Profiles to authenticate to AWS. This adds a prompt to the new hook as well, which asks the user to choose between the Access/Secret Keypair that has been the behavior up until now, and IAM Instance Profiles. In the case of proto bosh, it should also ask for the instance profile to associate with the proto bosh director VM.