### PR TITLE
merge external-db-ca into external-db

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -414,20 +414,19 @@ simply `external-db`) feature.
 
 To use an external MySQL database, activate the `external-db-mysql` feature.
 
-These features require a param in the environment yaml `external_db_host`, the
-hostname of the database.
+When using either of these features, the following parameters are required:
 
-If your external database needs to be MySQL instead of the default of
-Postgres, additionally activate the `external-db-mysql` feature.
+  - `external_db_host` - The hostname of the database for the BOSH Director,
+    CredHub, and UAA to connect to.
+  - `external_db_ca` - The CA certificate to use to verify the certificate
+    served by the external database instance.
 
-TLS is enabled by default for the database. If you need to provide bosh with 
-a CA for the external database, use the feature `external-db-ca` and specify 
-the param `external_db_ca` in the environment yaml. 
-
-TLS can be disabled with the feature `external-db-no-tls`.
+TLS is enabled by default for connecting to the external database. TLS can be
+disabled with the feature `external-db-no-tls`.
 
 The database usernames and names can be customized with the following
 parameters:
+
   - `bosh_db_user` - The username that the BOSH Director authenticates to the
     database with. Defaults to `bosh_user`.
   - `credhub_db_user` - The username that CredHub authenticates to the database

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -92,8 +92,14 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
       merge+=( 
         manifests/addons/external-db-internal-db-cleanup.yml \
         manifests/addons/external-db.yml \
-        manifests/addons/external-db-ca.yml 
       )
+
+      if ! want_feature external-db-no-tls; then
+        merge+=(
+          manifests/addons/external-db-ca.yml 
+        )
+      fi
+
       if want_feature external-db-mysql; then
         merge+=(
           manifests/addons/external-db-mysql.yml

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -105,8 +105,8 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
         )
       elif want_feature external-db-ca; then
         echo 'The BOSH director actually cannot be deployed without specifying an external CA' \
-          'and, consequently, this feature has been merged into `external-db`. You can remove this' \
-          'feature without any issues.' >&2
+          'and, consequently, this feature has been merged into `external-db-postgres` and' \
+          '`external-db-mysql`, respectively. You can remove this feature without any issues.' >&2
       fi
     fi
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -91,7 +91,8 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     if want_feature external-db || want_feature external-db-mysql || want_feature external-db-postgres; then
       merge+=( 
         manifests/addons/external-db-internal-db-cleanup.yml \
-        manifests/addons/external-db.yml 
+        manifests/addons/external-db.yml \
+        manifests/addons/external-db-ca.yml 
       )
       if want_feature external-db-mysql; then
         merge+=(
@@ -103,10 +104,9 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
           manifests/addons/external-db-no-tls.yml
         )
       elif want_feature external-db-ca; then
-        merge+=( 
-          manifests/addons/external-db-ca.yml 
-        )
-
+        echo 'The BOSH director actually cannot be deployed without specifying an external CA' \
+          'and, consequently, this feature has been merged into `external-db`. You can remove this' \
+          'feature without any issues.' >&2
       fi
     fi
 


### PR DESCRIPTION
You can't actually deploy the BOSH Director without specifying the DB CA when it is configured to use TLS when talking to the database. Therefore, this feature was already mandatory, so it's been merged into the main feature here.