### PR TITLE
Refactored to support derived features

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -23,7 +23,7 @@ merge=( \
 )
 
 iaas=0
-extdb=''
+extdb=
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
@@ -63,16 +63,14 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     fi
 
     if want_feature "${want}-init"; then
-      describe >&2 \
-        "The #c{${want}-init} feature no longer does anything. You should use the #c{proto} feature" \
+      bail \
+        "The #c{${want}-init} feature no longer does anything. You need to use the #c{proto} feature" \
         "instead, regardless of which CPI you're targeting"
     fi
 
     if want_feature "iam-instance-profile"; then
       [[ "$want" == "aws" ]] || bail "Cannot use IAM instance profiles if not deploying to AWS"
-
       merge+=( "manifests/addons/iam-profile.yml" )
-      want_feature "proto" && merge+=( "manifests/addons/proto-iam-profile.yml" )
     fi
 
     if want_feature "s3-blobstore"; then
@@ -82,12 +80,21 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
         merge+=( "manifests/addons/s3-blobstore-iam-profile.yml" )
       fi
     fi
+
+    if want_feature "proto" ; then
+      # If this is a proto-BOSH and one of the iam-instance-profile or
+      # s3-blobstore-iam-instance-profile features are requested, then we need
+      # to ensure the proto-BOSH has the correct cloud properties
+      if want_feature "iam-instance-profile" || want_feature "s3-blobstore-iam-instance-profile"; then
+        merge+=( "manifests/addons/proto-iam-profile.yml" )
+      fi
+    fi
     ;;
 
   external-db|external-db-mysql|external-db-postgres)
     [[ -z "$extdb" ]] || bail "Cannot specify both $want and $extdb - pick one"
     extdb="$want"
-    merge+=( 
+    merge+=( \
       "manifests/addons/external-db-internal-db-cleanup.yml" \
       "manifests/addons/external-db.yml" \
     )
@@ -99,7 +106,7 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
       merge+=( "manifests/addons/external-db-ca.yml" )
     fi
     ;;
-  
+
   vault-credhub-proxy)
     merge+=( "manifests/addons/vault-credhub-proxy.yml" )
     ;;
@@ -115,32 +122,25 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     describe >&2 \
       "The BOSH director actually cannot be deployed without specifying an external CA" \
       "and, consequently, this feature has been merged into #c{external-db-postgres} and" \
-      "#c{'external-db-mysql}, respectively. You can remove this feature without any issues."
+      "#c{external-db-mysql}, respectively. You can remove this feature without any issues."
     ;;
 
   proxy|credhub)
     describe >&2 \
-      "You no longer need to explicitly #c{$want} feature." \
+      "You no longer need to explicitly specify the #c{$want} feature." \
       "If you remove it, everything will still work as expected."
     ;;
 
   esac
 done
 
-if ! want_feature skip-op-users; then
-  merge+=( "manifests/addons/op-users.yml" )
-fi
+want_feature "skip-op-users" || merge+=( "manifests/addons/op-users.yml" )
 
 # Sanity Check Time!
 # If we haven't chosen an IaaS, that's a problem.
-if [[ $iaas == 0 ]]; then
-  echo >&2 "You have not enabled an IaaS feature flag."
-  exit 1
-fi
+[[ $iaas == 0 ]] && bail "You have not enabled an IaaS feature flag."
+
 # If we have chosen more than one IaaS, that's a problem.
-if [[ $iaas -gt 1 ]]; then
-  echo >&2 "You have enabled more than one IaaS feature flag."
-  exit 1
-fi
+[[ $iaas -gt 1 ]] && bail "You have enabled more than one IaaS feature flag."
 
 echo "${merge[@]}"

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -9,17 +9,21 @@ validate_features aws azure google openstack vsphere warden \
                   proxy credhub shield bosh proto skip-op-users registry vault-credhub-proxy \
                   external-db external-db-ca external-db-no-tls s3-blobstore \
                   iam-instance-profile s3-blobstore-iam-instance-profile \
-                  external-db-mysql external-db-postgres
+                  external-db-mysql external-db-postgres \
+                  +aws-secret-access-keys +s3-blobstore-secret-access-keys +internal-blobstore
 
 #
 # We always start out with the skeleton of a BOSH deployment,
 # and add-in a local UAA and a Credhub
-merge=( manifests/versions.yml
-        manifests/bosh/bosh.yml
-        manifests/bosh/uaa.yml
-        manifests/bosh/credhub.yml )
+merge=( \
+  "manifests/versions.yml" \
+  "manifests/bosh/bosh.yml" \
+  "manifests/bosh/uaa.yml" \
+  "manifests/bosh/credhub.yml" \
+)
 
 iaas=0
+extdb=''
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
@@ -29,34 +33,32 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
   aws|aws-cpi|azure|azure-cpi|google|google-cpi|openstack|openstack-cpi|vsphere|vpshere-cpi|warden|warden-cpi)
     if [[ $want =~ .*-cpi ]]; then
       want=${want%-cpi}
-      echo "The '${want}-cpi' feature is now deprecated. You should use '${want}' instead." >&2
+      echo "The #c{${want}-cpi} feature is now deprecated. You should use #c{${want}} instead." >&2
     fi
 
     iaas=$(( iaas + 1 ))
     merge+=( "manifests/iaas/${want}.yml" )
 
-    if want_feature registry; then
+    if want_feature "registry"; then
       #  Azure, AWS, Google, and Openstack do not need a registry anymore,
       #  but you may still need it if you have deployments with stemcells
       #  that are too old to take advantage of this.
       #  Additionally, vSphere and Warden don't need a registry in any cases.
-      merge+=( manifests/addons/registry.yml )
+      merge+=( "manifests/addons/registry.yml" )
     fi
 
-    if want_feature proto; then
-      if [[ $want == "warden" ]]; then
-        # It doesn't make sense to deploy a proto-BOSH to Warden,
-        # since Warden is the only IaaS that doesn't exist in its
-        # own right, apart from BOSH.  There is now "Warden" cloud...
-        #
-        printf >&2 "BOSH Warden CPI can not be deployed as a proto-BOSH"
-        exit 2
-      fi
+    if want_feature "proto"; then
+      # It doesn't make sense to deploy a proto-BOSH to Warden, since Warden is
+      # the only IaaS that doesn't exist in its own right, apart from BOSH.
+      # There is now "Warden" cloud...
+      [[ $want == "warden" ]] && bail "BOSH Warden CPI can not be deployed as a proto-BOSH"
 
-      merge+=( manifests/bosh/proto.yml
-               "manifests/proto/${want}.yml" )
+      merge+=( \
+        "manifests/bosh/proto.yml" \
+        "manifests/proto/${want}.yml" \
+      )
     else
-      merge+=( manifests/bosh/env.yml )
+      merge+=( "manifests/bosh/env.yml" )
     fi
 
     if want_feature "${want}-init"; then
@@ -64,87 +66,63 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
         "instead, regardless of which CPI you're targeting" >&2
     fi
 
-    if want_feature vault-credhub-proxy; then
-      merge+=(
-        manifests/addons/vault-credhub-proxy.yml \
-      )
+    if want_feature "iam-instance-profile"; then
+      [[ "$want" == "aws" ]] || bail"Cannot use IAM instance profiles if not deploying to AWS"
+
+      merge+=( "manifests/addons/iam-profile.yml" )
+      want_feature "proto" && merge+=( "manifests/addons/proto-iam-profile.yml" )
     fi
 
-    if want_feature iam-instance-profile; then
-      if [[ $want != "aws" ]]; then
-        printf >&2 "Cannot use IAM instance profiles if not deploying to AWS"
-        exit 2
-      fi
-
-      merge+=(
-        manifests/addons/iam-profile.yml
-      )
-
-      if want_feature proto; then
-        merge+=(
-          manifests/addons/proto-iam-profile.yml
-        )    
-      fi
-
-    fi
-
-    if want_feature external-db || want_feature external-db-mysql || want_feature external-db-postgres; then
-      merge+=( 
-        manifests/addons/external-db-internal-db-cleanup.yml \
-        manifests/addons/external-db.yml \
-      )
-
-      if ! want_feature external-db-no-tls; then
-        merge+=(
-          manifests/addons/external-db-ca.yml 
-        )
-      fi
-
-      if want_feature external-db-mysql; then
-        merge+=(
-          manifests/addons/external-db-mysql.yml
-        )
-      fi
-      if want_feature external-db-no-tls; then
-        merge+=(
-          manifests/addons/external-db-no-tls.yml
-        )
-      elif want_feature external-db-ca; then
-        echo 'The BOSH director actually cannot be deployed without specifying an external CA' \
-          'and, consequently, this feature has been merged into `external-db-postgres` and' \
-          '`external-db-mysql`, respectively. You can remove this feature without any issues.' >&2
+    if want_feature "s3-blobstore"; then
+      merge+=( "manifests/addons/s3-blobstore.yml" )
+      if want_feature "s3-blobstore-iam-instance-profile"; then
+        [[ "$want" == "aws" ]] || bail "Cannot use IAM instance profiles if not deploying to AWS"
+        merge+=( "manifests/addons/s3-blobstore-iam-profile.yml" )
       fi
     fi
+    ;;
 
-    if want_feature s3-blobstore; then
-      merge+=(
-        manifests/addons/s3-blobstore.yml
-      )
+  external-db|external-db-mysql|external-db-postgres)
+    [[ -z "$extdb" ]] || bail "Cannot specify both $want and $extdb - pick one"
+    extdb="$want"
+    merge+=( 
+      "manifests/addons/external-db-internal-db-cleanup.yml" \
+      "manifests/addons/external-db.yml" \
+    )
+    [[ "$want" == "external-db-mysql" ]] && merge+=( "manifests/addons/external-db-mysql.yml" )
 
-      if want_feature s3-blobstore-iam-instance-profile; then
-        merge+=(
-          manifests/addons/s3-blobstore-iam-profile.yml
-        )
-      fi
+    if want_feature "external-db-no-tls" ; then
+      merge+=( "manifests/addons/external-db-no-tls.yml" )
+    else
+      merge+=( "manifests/addons/external-db-ca.yml" )
     fi
-
-
+    ;;
+  
+  vault-credhub-proxy)
+    merge+=( "manifests/addons/vault-credhub-proxy.yml" )
     ;;
 
   # Deprecated (now-noop) feature flags
   shield)
-    echo >&2 "The 'shield' feature is no longer supported.  Instead, please add the"
+    echo >&2 "The #c{shield} feature is no longer supported.  Instead, please add the"
     echo >&2 "shield agent to your runtime configuration."
     ;;
 
+  external-db-ca)
+    describe >&2 \
+      "The BOSH director actually cannot be deployed without specifying an external CA" \
+      "and, consequently, this feature has been merged into #c{external-db-postgres} and" \
+      "#c{'external-db-mysql}, respectively. You can remove this feature without any issues."
+    ;;
+
   proxy|credhub)
-    echo >&2 "You no longer need to explicitly '$want' feature."
+    echo >&2 "You no longer need to explicitly #c{$want} feature."
     echo >&2 "If you remove it, everything will still work as expected."
   esac
 done
 
 if ! want_feature skip-op-users; then
-  merge+=( manifests/addons/op-users.yml )
+  merge+=( "manifests/addons/op-users.yml" )
 fi
 
 # Sanity Check Time!

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -33,7 +33,8 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
   aws|aws-cpi|azure|azure-cpi|google|google-cpi|openstack|openstack-cpi|vsphere|vpshere-cpi|warden|warden-cpi)
     if [[ $want =~ .*-cpi ]]; then
       want=${want%-cpi}
-      echo "The #c{${want}-cpi} feature is now deprecated. You should use #c{${want}} instead." >&2
+      describe >&2 \
+        "The #c{${want}-cpi} feature is now deprecated. You should use #c{${want}} instead."
     fi
 
     iaas=$(( iaas + 1 ))
@@ -62,12 +63,13 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     fi
 
     if want_feature "${want}-init"; then
-      echo "The '${want}-init' feature no longer does anything. You should use the 'proto' feature" \
-        "instead, regardless of which CPI you're targeting" >&2
+      describe >&2 \
+        "The #c{${want}-init} feature no longer does anything. You should use the #c{proto} feature" \
+        "instead, regardless of which CPI you're targeting"
     fi
 
     if want_feature "iam-instance-profile"; then
-      [[ "$want" == "aws" ]] || bail"Cannot use IAM instance profiles if not deploying to AWS"
+      [[ "$want" == "aws" ]] || bail "Cannot use IAM instance profiles if not deploying to AWS"
 
       merge+=( "manifests/addons/iam-profile.yml" )
       want_feature "proto" && merge+=( "manifests/addons/proto-iam-profile.yml" )
@@ -104,8 +106,9 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
 
   # Deprecated (now-noop) feature flags
   shield)
-    echo >&2 "The #c{shield} feature is no longer supported.  Instead, please add the"
-    echo >&2 "shield agent to your runtime configuration."
+    describe >&2 \
+      "The #c{shield} feature is no longer supported.  Instead, please add the" \
+      "shield agent to your runtime configuration."
     ;;
 
   external-db-ca)
@@ -116,8 +119,11 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     ;;
 
   proxy|credhub)
-    echo >&2 "You no longer need to explicitly #c{$want} feature."
-    echo >&2 "If you remove it, everything will still work as expected."
+    describe >&2 \
+      "You no longer need to explicitly #c{$want} feature." \
+      "If you remove it, everything will still work as expected."
+    ;;
+
   esac
 done
 

--- a/hooks/features
+++ b/hooks/features
@@ -1,14 +1,9 @@
 #!/bin/bash
 echo "$GENESIS_REQUESTED_FEATURES"
 if want_feature "aws" || want_feature "aws-cpi"; then
-  if ! want_feature "iam-instance-profile"; then
-    echo "+aws-secret-access-keys"
-  fi
+  want_feature "iam-instance-profile" || echo "+aws-secret-access-keys"
   if want_feature "s3-blobstore" ; then
     want_feature "s3-blobstore-iam-instance-profile" || echo "+s3-blobstore-secret-access-keys"
-  else
-    echo "+internal-blobstore"
   fi
-else
- want_feature "s3-blobstore" || echo "+internal-blobstore"
 fi
+want_feature "s3-blobstore" || echo "+internal-blobstore"

--- a/hooks/features
+++ b/hooks/features
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo "$GENESIS_REQUESTED_FEATURES"
+if want_feature "aws" || want_feature "aws-cpi"; then
+  if ! want_feature "iam-instance-profile"; then
+    echo "+aws-secret-access-keys"
+  fi
+  if want_feature "s3-blobstore" ; then
+    want_feature "s3-blobstore-iam-instance-profile" || echo "+s3-blobstore-secret-access-keys"
+  else
+    echo "+internal-blobstore"
+  fi
+else
+ want_feature "s3-blobstore" || echo "+internal-blobstore"
+fi

--- a/hooks/new
+++ b/hooks/new
@@ -18,7 +18,7 @@ prompt_for ip line \
 	'What static IP do you want to deploy this BOSH director on?' \
 	--validation ip
 
-if [[ $isproto == 'true' ]]; then
+if [[ "$isproto" == 'true' ]]; then
 	proto_net=
 	prompt_for proto_net line \
 		'What network should this BOSH director exist in (in CIDR notation)?'
@@ -45,13 +45,13 @@ prompt_for iaas "select" \
 	-o '[warden]    BOSH Warden'
 
 features=()
-case $iaas in
+aws_iam_profile_name=
+case "$iaas" in
 aws)
 	aws_region=
 	prompt_for aws_region line \
 		'What AWS region would you like to deploy to?'
 
-	aws_iam_profile_name=
 	aws_auth_method=
 	prompt_for aws_auth_method "select" \
 	  'How will this BOSH director authenticate to AWS?' \
@@ -59,17 +59,12 @@ aws)
 		-o '[profile]    IAM Instance Profile'  
 	
 	if [[ $aws_auth_method == 'access_key' ]]; then
-		aws_access_key=
-		prompt_for aws_access_key line \
+		prompt_for aws:access_key secret-line --echo \
 			'What is your AWS Access Key?'
 		prompt_for aws:secret_key secret-line \
 			'What is your AWS Secret Key?'
-		safe set --quiet "${GENESIS_SECRETS_BASE}aws" access_key="$aws_access_key"
-  else
-	  features+=( \
-			"iam-instance-profile" \
-		)
-
+	else
+		features+=( "iam-instance-profile" )
 		if [[ $isproto == 'true' ]]; then
 			prompt_for aws_iam_profile_name line \
 				'What AWS IAM instance profile should the Proto-BOSH VM have associated with it?'
@@ -80,7 +75,7 @@ aws)
 	prompt_for aws_default_sgs multi-line \
 		'What security groups should the all deployed VMs be placed in?'
 
-	if [[ $isproto == 'true' ]]; then
+	if [[ "$isproto" == 'true' ]]; then
 		aws_subnet=
 		prompt_for aws_subnet line \
 			'What is the ID of the AWS subnet you want to deploy to?'
@@ -138,7 +133,7 @@ vsphere)
 	same_datastores=
 	prompt_for same_datastores boolean \
 		'Do you wish to use these same data stores for persistent (data) disks?'
-	if [[ $same_datastores == 'false' ]]; then
+	if [[ "$same_datastores" == 'false' ]]; then
 		vsphere_persistents=
 		prompt_for vsphere_persistents multi-line -m 1 \
 			'What data stores do you wish to use for persistent (data) disks?'
@@ -146,7 +141,7 @@ vsphere)
 		vsphere_persistents=("${vsphere_ephemerals[@]}")
 	fi
 
-	if [[ $isproto == 'true' ]]; then
+	if [[ "$isproto" == 'true' ]]; then
 		vsphere_net=
 		prompt_for vsphere_net line \
 			'What is the name of the VM network in vCenter to deploy BOSH to?'
@@ -162,7 +157,7 @@ google)
 		'What are your GCP credentials (generally supplied as a JSON block)?'
 	safe set --quiet "${GENESIS_SECRETS_BASE}google" json_key="$google_json_key"
 
-	if [[ $isproto == 'true' ]]; then
+	if [[ "$isproto" == 'true' ]]; then
 		google_net=
 		prompt_for google_net line \
 			'What is your GCP network name?'
@@ -202,7 +197,7 @@ azure)
 	prompt_for azure_default_sg line \
 		'What security group should be used as the BOSH default security group?'
 
-	if [[ $isproto == "true" ]]; then
+	if [[ "$isproto" == "true" ]]; then
 		azure_vnet=
 		prompt_for azure_vnet line \
 			'What is the name of your Azure Virtual Network?'
@@ -242,7 +237,7 @@ openstack)
 	prompt_for openstack_default_sgs multi-line \
 		'What default security groups should be applied to VMs created by BOSH?'
 
-	if [[ $isproto == "true" ]]; then
+	if [[ "$isproto" == "true" ]]; then
 		openstack_network_id=
 		prompt_for openstack_network_id line \
 			'What is the UUID of the OpenStack network that BOSH will be placed in?'
@@ -258,43 +253,45 @@ esac
 
 blobstore=
 prompt_for blobstore "select" \
-  'What Blobstore do you want to use?' \
-  -o '[internal] Create a local blobstore on the BOSH director VM' \
-  -o '[s3]       Use an existing AWS S3 Blobstore'\
-  --default "internal"
+	'What Blobstore do you want to use?' \
+	-o '[internal] Create a local blobstore on the BOSH director VM' \
+	-o '[s3]       Use an existing AWS S3 Blobstore'\
+	--default "internal"
 
 blobstore_s3_bucket=
 blobstore_s3_region=
 blobstore_s3_auth_method=
-if [[ "$blobstore" == 's3' ]] ; then
-  features+=( "s3-blobstore" )
-  prompt_for blobstore_s3_bucket line \
-    "What is the name of the S3 Bucket?"
-  prompt_for blobstore_s3_region line \
-    "What region contains the '$blobstore_s3_bucket' S3 Bucket?"
+if [[ "$blobstore" == 's3' ]]; then
+	features+=( "s3-blobstore" )
+	prompt_for blobstore_s3_bucket line \
+		"What is the name of the S3 Bucket?"
+	prompt_for blobstore_s3_region line \
+		"What region contains the '$blobstore_s3_bucket' S3 Bucket?"
 
-  if [[ "$iaas" == "aws" ]] ; then # TODO: Should profile only be allowed for aws and not proto if aws_auth_method isn't profile
-    prompt_for blobstore_s3_auth_method "select" \
-      'How will this BOSH director authenticate to S3?' \
-      -o '[access_key] Access/Secret Keypair' \
-      -o '[profile]    IAM Instance Profile' \
-      --default "$aws_auth_method"
-  else
-    blobstore_s3_auth_method='access_key'
-  fi
+	blobstore_s3_auth_method='access_key'
+	if [[ "$iaas" == "aws" ]]; then
+		prompt_for blobstore_s3_auth_method "select" \
+			'How will this BOSH director authenticate to S3?' \
+			-o '[access_key] Access/Secret Keypair' \
+			-o '[profile]		 IAM Instance Profile' \
+			--default "$aws_auth_method"
+	fi
 
-  if [[ $blobstore_s3_auth_method == 'access_key' ]]; then
-    blobstore_s3_access_key=
-    prompt_for blobstore_s3_access_key line \
-      "What is your AWS Access Key for the '$blobstore_s3_bucket' S3 Bucket?"
-    prompt_for blobstore/s3:secret_key secret-line \
-      "What is your AWS Secret Key for the '$blobstore_s3_bucket' S3 Bucket?"
-    safe set --quiet "${GENESIS_SECRETS_BASE}blobstore/s3" access_key="$blobstore_s3_access_key"
-  else
-    features+=( "s3-blobstore-iam-instance-profile" )
-  fi
+	if [[ "$blobstore_s3_auth_method" == 'access_key' ]]; then
+		blobstore_s3_access_key=
+		prompt_for blobstore/s3:access_key secret-line --echo \
+			"What is your AWS Access Key for the '$blobstore_s3_bucket' S3 Bucket?" \
+		prompt_for blobstore/s3:secret_key secret-line \
+			"What is your AWS Secret Key for the '$blobstore_s3_bucket' S3 Bucket?"
+		safe set --quiet "${GENESIS_SECRETS_BASE}blobstore/s3" access_key="$blobstore_s3_access_key"
+	else
+		features+=( "s3-blobstore-iam-instance-profile" )
+		if [[ "$isproto" == 'true' && -z "$aws_iam_profile_name" ]]; then
+			prompt_for aws_iam_profile_name line \
+				'What AWS IAM instance profile should the Proto-BOSH VM have associated with it?'
+		fi
+	fi
 fi
-
 
 ###########################################################################
 
@@ -489,11 +486,11 @@ openstack)
 
 esac
 
-if [[ "$blobstore" == "s3" ]] ; then
-  echo "  # Configure for using an external S3 Blobstore"
-  echo "  s3_blobstore_bucket: $blobstore_s3_bucket"
-  echo "  s3_blobstore_region: $blobstore_s3_region"
-  echo 
+if [[ "$blobstore" == "s3" ]]; then
+	echo "  # External S3 Blobstore Configuration"
+	echo "  s3_blobstore_bucket: $blobstore_s3_bucket"
+	echo "  s3_blobstore_region: $blobstore_s3_region"
+	echo
 fi
 ) > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"
 

--- a/hooks/new
+++ b/hooks/new
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -u
 #Version check
-min_version="2.7.0"
+min_version="2.7.8"
 genesis_version="$(genesis -v 2>&1 | grep '^Genesis v' | sed -e 's/Genesis v\(.*\) (.*$/\1/')"
 if ! [[ "$genesis_version" =~ -dev$ ]] && ! new_enough "$genesis_version" "$min_version" ; then
   describe >&2 "" "#R{[ERROR]} This kit needs Genesis $min_version.  Please upgrade before continuing" ""
@@ -35,7 +35,7 @@ fi
 ###########################################################################
 
 iaas=
-prompt_for iaas select \
+prompt_for iaas "select" \
 	'What IaaS will this BOSH director orchestrate?' \
 	-o '[vsphere]   VMWare vSphere'        \
 	-o '[aws]       Amazon Web Services'   \
@@ -51,10 +51,9 @@ aws)
 	prompt_for aws_region line \
 		'What AWS region would you like to deploy to?'
 
-
 	aws_iam_profile_name=
 	aws_auth_method=
-	prompt_for aws_auth_method select \
+	prompt_for aws_auth_method "select" \
 	  'How will this BOSH director authenticate to AWS?' \
 		-o '[access_key] Access/Secret Keypair' \
 		-o '[profile]    IAM Instance Profile'  
@@ -67,9 +66,9 @@ aws)
 			'What is your AWS Secret Key?'
 		safe set --quiet "${GENESIS_SECRETS_BASE}aws" access_key="$aws_access_key"
   else
-	  features+=(
-			"iam-instance-profile"
-		) 
+	  features+=( \
+			"iam-instance-profile" \
+		)
 
 		if [[ $isproto == 'true' ]]; then
 			prompt_for aws_iam_profile_name line \
@@ -256,6 +255,46 @@ openstack)
 	fi
 	;;
 esac
+
+blobstore=
+prompt_for blobstore "select" \
+  'What Blobstore do you want to use?' \
+  -o '[internal] Create a local blobstore on the BOSH director VM' \
+  -o '[s3]       Use an existing AWS S3 Blobstore'\
+  --default "internal"
+
+blobstore_s3_bucket=
+blobstore_s3_region=
+blobstore_s3_auth_method=
+if [[ "$blobstore" == 's3' ]] ; then
+  features+=( "s3-blobstore" )
+  prompt_for blobstore_s3_bucket line \
+    "What is the name of the S3 Bucket?"
+  prompt_for blobstore_s3_region line \
+    "What region contains the '$blobstore_s3_bucket' S3 Bucket?"
+
+  if [[ "$iaas" == "aws" ]] ; then # TODO: Should profile only be allowed for aws and not proto if aws_auth_method isn't profile
+    prompt_for blobstore_s3_auth_method "select" \
+      'How will this BOSH director authenticate to S3?' \
+      -o '[access_key] Access/Secret Keypair' \
+      -o '[profile]    IAM Instance Profile' \
+      --default "$aws_auth_method"
+  else
+    blobstore_s3_auth_method='access_key'
+  fi
+
+  if [[ $blobstore_s3_auth_method == 'access_key' ]]; then
+    blobstore_s3_access_key=
+    prompt_for blobstore_s3_access_key line \
+      "What is your AWS Access Key for the '$blobstore_s3_bucket' S3 Bucket?"
+    prompt_for blobstore/s3:secret_key secret-line \
+      "What is your AWS Secret Key for the '$blobstore_s3_bucket' S3 Bucket?"
+    safe set --quiet "${GENESIS_SECRETS_BASE}blobstore/s3" access_key="$blobstore_s3_access_key"
+  else
+    features+=( "s3-blobstore-iam-instance-profile" )
+  fi
+fi
+
 
 ###########################################################################
 
@@ -449,6 +488,13 @@ openstack)
 	;;
 
 esac
+
+if [[ "$blobstore" == "s3" ]] ; then
+  echo "  # Configure for using an external S3 Blobstore"
+  echo "  s3_blobstore_bucket: $blobstore_s3_bucket"
+  echo "  s3_blobstore_region: $blobstore_s3_region"
+  echo 
+fi
 ) > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"
 
 offer_environment_editor

--- a/kit.yml
+++ b/kit.yml
@@ -7,7 +7,7 @@ docs:    https://github.com/genesis-community/bosh-genesis-kit
 code:    https://github.com/genesis-community/bosh-genesis-kit
 version: 1.11.1-rc1
 
-genesis_version_min: 2.7.6
+genesis_version_min: 2.7.8
 
 certificates:
   base:
@@ -80,10 +80,6 @@ credentials:
     op/sys:
       password: random 12 fmt crypt-sha512
 
-    blobstore/agent:
-      password: random 64 fixed
-    blobstore/director:
-      password: random 64
     db:
       password: random 64
     nats:
@@ -150,34 +146,30 @@ credentials:
     openstack/ssh: ssh 2048
   openstack-cpi: *openstack
 
-provided:
-# if the user provides iam-instance-profile, then we would not want genesis to
-# force the user to have access and secret keys. Until there is a feature that
-# allows this functionality, just don't enforce these keys for now.
-#
-#  aws: &provided_aws
-#    aws:
-#      keys:
-#        secret_key:
-#          prompt:    AWS Secret Key
-#        access_key:
-#          sensitive: false
-#          prompt:    AWS Access Key
-#  aws-cpi: *provided_aws
+  +internal-blobstore:
+    blobstore/agent:
+      password: random 64 fixed
+    blobstore/director:
+      password: random 64
 
-# if the user provides s3-blobstore-iam-instance-profile, then we would not
-# want genesis to force the user to have access and secret keys. Until there is
-# a feature that allows this functionality, just don't enforce these keys for
-# now.
-#
-#  s3-blobstore:
-#    blobstore/s3:
-#      keys:
-#        access_key:
-#          sensitive: false
-#          prompt:    AWS Blobstore Access Key
-#        secret_key:
-#          prompt:    AWS Blobstore Secret Key
+provided:
+  +aws-secret-access-keys:
+    aws:
+      keys:
+        secret_key:
+          prompt:    AWS Secret Key
+        access_key:
+          sensitive: false
+          prompt:    AWS Access Key
+
+  +s3-blobstore-secret-access-keys:
+    blobstore/s3:
+      keys:
+        access_key:
+          sensitive: false
+          prompt:    AWS Blobstore Access Key
+        secret_key:
+          prompt:    AWS Blobstore Secret Key
 
   vsphere: &provided_vsphere
     vsphere:


### PR DESCRIPTION
The addition of iam-instance-profiles and s3 buckets required derived
features to validate secrets that need to be present when those new
features AREN'T present.

Further refactored the blueprint hook to facilitate better condition
checking and merge orders.

Prefixing derived features with a + is convention at this time, but it is intended that they will be ignored by the validate_features helper, and may be verified not to be explicitly stated in env files.