### PR TITLE
Add blacksmith-integration support

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -407,6 +407,13 @@ create and auth to a `safe target` pointing at this proxy. Please note
 that this proxy does not support every safe function. It does support
 basic functionality making credhub management a bit easier.
 
+# Blacksmith Integration
+
+To enable blacksmith use of this BOSH director for deploying services activate
+the `blacksmith-integration` feature. This will add a 'blacksmith' user that
+only has permissions to interact with its own deployments and upload releases
+and stemcells and expose it via exodus data to the blacksmith kit.
+
 # External Database Support
 
 This kit supports using a database for the BOSH Director, UAA, and CredHub

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,10 @@
+# Improvements
+
+* Added a `blacksmith-integration` feature:
+
+  * Allows the blacksmith genesis
+  kit to seamlessly use a director deployed by the bosh genesis kit to deploy
+  services.
+  * This will add a `blacksmith` user that
+  only has permissions to interact with its own deployments, upload releases,
+  and upload stemcells

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -9,7 +9,7 @@ validate_features aws azure google openstack vsphere warden \
                   proxy credhub shield bosh proto skip-op-users registry vault-credhub-proxy \
                   external-db external-db-ca external-db-no-tls s3-blobstore \
                   iam-instance-profile s3-blobstore-iam-instance-profile \
-                  external-db-mysql external-db-postgres \
+                  external-db-mysql external-db-postgres blacksmith-integration \
                   +aws-secret-access-keys +s3-blobstore-secret-access-keys +internal-blobstore +external-db
 
 #
@@ -109,6 +109,10 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
 
   vault-credhub-proxy)
     merge+=( "manifests/addons/vault-credhub-proxy.yml" )
+    ;;
+
+  blacksmith-integration)
+    merge+=( "manifests/addons/blacksmith-integration.yml" )
     ;;
 
   # Deprecated (now-noop) feature flags

--- a/kit.yml
+++ b/kit.yml
@@ -121,6 +121,10 @@ credentials:
     uaa/users/credhub-admin:
       password: random 32
 
+  blacksmith-integration:
+    users/blacksmith:
+      password: random 30
+
   proto: &proto
     mbus_bootstrap:
       password: random 64

--- a/manifests/addons/blacksmith-integration.yml
+++ b/manifests/addons/blacksmith-integration.yml
@@ -1,0 +1,28 @@
+---
+exodus:
+  blacksmith_user: blacksmith
+  blacksmith_password: (( vault meta.vault "/users/blacksmith:password" ))
+
+
+instance_groups:
+- name: bosh
+  jobs:
+  - name: uaa
+    properties:
+      uaa:
+        scim:
+          users:
+          - (( append ))
+          - name: blacksmith
+            groups:
+              - bosh.teams.blacksmith.admin
+              - bosh.stemcells.upload
+              - bosh.releases.upload
+            password: (( vault meta.vault "/users/blacksmith:password" ))
+        clients:
+          blacksmith:
+            override: true
+            authorized-grant-types: client_credentials
+            scope: ""
+            authorities: bosh.teams.blacksmith.admin,bosh.stemcells.upload,bosh.releases.upload
+            secret: (( vault meta.vault "/users/blacksmith:password" ))


### PR DESCRIPTION
This user is to allow blacksmith to leverage an existing director
and all of the configs that come with it for service deployments

Adds a blacksmith user with team level scope to the bosh director
This user will not be able to interact with any deployments it did not create

The releases and stemcells scopes can likely be removed as they are usually handled
when adding a forge to blacksmith itself, however if this changes in the future
the support is already here for that.