### PR TITLE
Allow credhub cli to use client/secret auth

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,13 @@
+# Improvements
+
+- Allow credhub cli to connect via client/secret auth as well as
+  username/password.
+
+  The `credhub-login` addon will continue to use the username/password method,
+  creating a local token.  However, when other kits need to access the bosh's
+  credhub for their own secrets management needs, they will provide
+  `CREDHUB_*` environment variables and connect via client/secrets method.
+
+  This functionality change is available in and required by Genesis v2.7.11.
+  Please upgrade to Genesis v2.7.11, then deploy this version of the bosh kit
+  prior to deploying any further kits.

--- a/hooks/addon
+++ b/hooks/addon
@@ -68,6 +68,8 @@ credhub_login() {
   # Update api target with correct ca's
   unset CREDHUB_SECRET
   unset CREDHUB_CLIENT
+  unset CREDHUB_SERVER
+  unset CREDHUB_CA_CERT
   command credhub api "https://$(lookup params.static_ip):8844" --ca-cert <(safe read "${GENESIS_SECRETS_BASE}ssl/ca:certificate"; safe read "${GENESIS_SECRETS_BASE}credhub/ca:certificate")
 
   # Login via stored password

--- a/manifests/bosh/credhub.yml
+++ b/manifests/bosh/credhub.yml
@@ -61,7 +61,15 @@ instance_groups:
                 access-token-validity: 3600
                 secret: (( vault meta.vault "/uaa/clients/director_to_credhub:secret" ))
 
-              credhub_cli:
+              credhub-cli: # credhub cli via client/secret
+                override: true
+                authorized-grant-types: client_credentials
+                scope: ""
+                authorities: credhub.read,credhub.write
+                access-token-validity: 3600
+                secret: (( vault meta.vault "/uaa/users/credhub-cli:password" ))
+
+              credhub_cli: # credhub cli via username/password
                 override: true
                 authorized-grant-types: password,refresh_token
                 scope: credhub.read,credhub.write


### PR DESCRIPTION
Allow credhub cli to connect via client/secret auth as well as  username/password.

The `credhub-login` addon will continue to use the username/password method, creating a local token.  However, when other kits need to access the bosh's credhub for their own secrets management needs, they will provide `CREDHUB_*` environment variables and connect via client/secrets method.

This functionality change is available in and required by Genesis v2.7.11.  Please upgrade to Genesis v2.7.11, then deploy this version of the bosh kit prior to deploying any further kits.