### PR TITLE
Add overlay to honour params.availability_zones

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -271,6 +271,9 @@ if ! want_feature skip-op-users; then
           overlay/addons/op-users.yml )
 fi
 
+  # Use params.availability_zones if set, otherwise default to "z1"
+  merge+=( overlay/set-availability-zone.yml )
+
 # Upgrade check
 set +e
 version="$(exodus kit_version)"  #TODO: if no exodus version is there (first run)

--- a/overlay/no-proto.yml
+++ b/overlay/no-proto.yml
@@ -38,10 +38,6 @@
   value: default
 
 - type: replace
-  path: /instance_groups/name=bosh/azs?
-  value: [z1]
-
-- type: replace
   path: /update?
   value:
     serial: true

--- a/overlay/set-availability-zone.yml
+++ b/overlay/set-availability-zone.yml
@@ -1,0 +1,4 @@
+instance_groups:
+- name: bosh
+  azs:
+    - (( grab params.availability_zones[0] || "z1" ))


### PR DESCRIPTION
In the 1.x bosh genesis kits you could set the availability zone for BOSH.  This was lost in the change to bosh-deployments.  Updated the kit to honour the value again if present.