### PR TITLE
Adding libvirt CPI

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -378,22 +378,22 @@ To deploy a BOSH director in a "BOSH-Lite" configuration using Warden containers
 To deploy a BOSH director onto a libvirt host, activate the `libvirt` feature and provide the following parameters:
 
 - `libvirt_network_name` - The name of the `libvirt` network.
-  **Required**
+  *Default:* `bosh`.
 - `libvirt_storage_pool_name` - The name of the `libvirt` storage pool.
-  **Required**
+  *Default:* `bosh`.
 - `libvirt_host` - The name of the `libvirt` host.
   **Required**
 - `libvirt_port` - The TLS port that `libvirt` listens on.
-  **Required**
+  *Default:* `16514`.
 
 If you also specify the `proto` feature, it requires a bit more configuration:
 
 - `libvirt_bosh_cpu` - Number of CPUs to give the BOSH Director.
-  **Required**
+  *Default:* `2`.
 - `libvirt_bosh_memory` - How much memory to give the BOSH Director.
-  **Required**
+  *Default:* `4096`.
 - `libvirt_bosh_disk` - How large the ephemeral disk will be for the BOSH Director.
-  **Required**
+  *Default:* `16384`.
 
 The following secrets will be added to the vault during `genesis new` or `genesis add-secrets` for the environment, then pulled from the vault on deployment:
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -56,6 +56,7 @@ What IaaS will this BOSH director orchestrate?
   4) Google Cloud Platform
   5) OpenStack
   6) BOSH Warden
+  7) libvirt
 
 Select choice >
 ```
@@ -191,6 +192,7 @@ Each environment must specify at least one feature, which is which Infrastructur
 * `google` - for deploying to Google Cloud Platform
 * `openstack` - for deploying to OpenStack
 * `warden` - for deploying to BOSH Warden containers
+* `libvirt` - for deploying KVM or QEMU VMs to a libvirt host
 
 #### Deploying to Amazon Web Services: `aws`
 
@@ -369,6 +371,43 @@ The following secrets will be created during `genesis new` or `genesis add-secre
 #### Deploying to Bosh Warden Containers: `warden`
 
 To deploy a BOSH director in a "BOSH-Lite" configuration using Warden containers for its deployment, use the `warden` feature.  **NOTE:** the `warden` feature does not support `proto` deployments at this time.
+
+
+#### Deploying to libvirt-based VMs: `libvirt`
+
+To deploy a BOSH director onto a libvirt host, activate the `libvirt` feature and provide the following parameters:
+
+- `libvirt_network_name` - The name of the `libvirt` network.
+  **Required**
+- `libvirt_storage_pool_name` - The name of the `libvirt` storage pool.
+  **Required**
+- `libvirt_host` - The name of the `libvirt` host.
+  **Required**
+- `libvirt_port` - The TLS port that `libvirt` listens on.
+  **Required**
+
+If you also specify the `proto` feature, it requires a bit more configuration:
+
+- `libvirt_bosh_cpu` - Number of CPUs to give the BOSH Director.
+  **Required**
+- `libvirt_bosh_memory` - How much memory to give the BOSH Director.
+  **Required**
+- `libvirt_bosh_disk` - How large the ephemeral disk will be for the BOSH Director.
+  **Required**
+
+The following secrets will be added to the vault during `genesis new` or `genesis add-secrets` for the environment, then pulled from the vault on deployment:
+
+- `libvirt/tls:client-cert` - The client certificate generated for authentication.
+  **Required**
+- `libvirt/tls:client-key` - The client private key generated for authentication.
+  **Required**
+- `libvirt/tls:server-ca` - The server CA.
+  **Required**
+
+Resources:
+* See the documentation on the [libvirt site](https://libvirt.org/), in particular the [Remote support](https://libvirt.org/remote.html) section.
+* Also see the [config section of libvirt-bosh-cpi](https://github.com/a2geek/libvirt-bosh-cpi/blob/master/docs/CONFIG.md)
+
 
 ### Amazon S3: `s3-blobstore` and `s3-blobstore-iam-instance-profile`
 

--- a/hooks/addon
+++ b/hooks/addon
@@ -159,6 +159,7 @@ stemcells() {
       openstack|openstack-cpi)  cpi="openstack-kvm" ;;
       vsphere|vpshere-cpi)      cpi="vsphere-esxi" ;;
       warden|warden-cpi)        cpi="warden-boshlite" ;;
+      libvirt)                  cpi="openstack-kvm" ;;
     esac
     if [[ -n "$cpi" ]] ; then
       if [[ -n "${prev_cpi:-}" && "$prev_cpi" != "$cpi" ]] ; then

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -89,12 +89,13 @@ for want in $GENESIS_REQUESTED_FEATURES; do
       warn=1;
       describe >&2 "" \
         "You no longer need to explicitly specify the #c{$want} feature." \
-        "If you remove it, everything will still work as expected."
+        "If you remove it, everything will  still work as expected."
       ;;
 
     proto|skip-op-users|vault-credhub-proxy|external-db-no-tls) features+=( "$want") ;;
     s3-blobstore|iam-instance-profile|s3-blobstore-iam-instance-profile) features+=( "$want") ;;
     node-exporter|blacksmith-integration|source-releases) features+=( "$want") ;;
+    libvirt-throttle-file-lock) features+=( "$want") ;; # libvirt specific
     bosh-dns-healthcheck|netop-access|sysop-access) features+=( "$want") ;; # runtime features
     \+*) features+=( "$want") ;; # virtual features
 
@@ -194,6 +195,11 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     else
       merge+=( overlay/no-proto.yml )
     fi
+    ;;
+  
+  libvirt-throttle-file-lock)
+    [[ "$iaas" == "libvirt" ]] || bail "" "Cannot use the throttling file-lock if not deploying to libvirt"
+    merge+=( "overlay/addons/libvirt-throttle-file-lock.yml" )
     ;;
 
   iam-instance-profile)

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -41,14 +41,14 @@ for want in $GENESIS_REQUESTED_FEATURES; do
       features+=( "${want%-cpi}" )
       ;;
 
-    aws-init|azure-init|google-init|openstack-init|vsphere-init|bosh-init)
+    aws-init|azure-init|google-init|openstack-init|vsphere-init|bosh-init|libvirt-init)
       warn=1
       describe >&2 \
         "#Y{[WARNING]} The #c{$want} feature is now two separate features: #c{${want%-init}} and #c{proto}"
       features+=( "${want%-init}" "proto" )
       ;;
 
-    aws|azure|google|openstack|vsphere|warden)
+    aws|azure|google|openstack|vsphere|warden|libvirt)
       if [[ -n "$iaas" ]] ; then
         abort=1
         describe >&2 \
@@ -127,7 +127,7 @@ for want in $GENESIS_REQUESTED_FEATURES; do
       ;;
   esac
 done
-[[ $iaas == 0 ]] && abort=1 && describe >&2 "You have not enabled an IaaS feature: aws, azure, google, openstack, vsphere or warden "
+[[ $iaas == 0 ]] && abort=1 && describe >&2 "You have not enabled an IaaS feature: aws, azure, google, openstack, vsphere, warden or libvirt "
 [[ "$abort" == "1" ]] && bail "#R{Cannot continue} - fix your #C{$GENESIS_ENVIRONMENT.yml} file to resolve these issues."
 [[ "$warn"  == "1" ]] && describe >&2 "" "Update your #C{$GENESIS_ENVIRONMENT.yml} file to remove these warnings." ""
 
@@ -174,6 +174,20 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
              "overlay/cpis/${want}.yml" )
 
     [[ $want == "azure" ]] && merge+=( "bosh-deployment/${want}/use-managed-disks.yml" )
+
+    if want_feature proto; then
+      merge+=( "overlay/cpis/${want}-proto.yml" )
+    else
+      merge+=( overlay/no-proto.yml )
+    fi
+    ;;
+
+  libvirt)
+    # Libvirt is not in the BOSH mainline repository; using a local copy of the CPI manifest
+    merge+=( "overlay/addons/libvirt-cpi.yml"
+             "overlay/addons/libvirt-tls.yml"
+             "overlay/addons/libvirt-openstack-stemcell.yml"
+             "overlay/cpis/${want}.yml" )
 
     if want_feature proto; then
       merge+=( "overlay/cpis/${want}-proto.yml" )

--- a/hooks/new
+++ b/hooks/new
@@ -290,6 +290,15 @@ libvirt)
 		--default 16514 \
 		--validation port
 
+	libvirt_throttle_file_lock=
+	prompt_for libvirt_throttle_file_lock boolean \
+		'Do you wish to enable the file-lock throttling mechanism?' \
+		--default false
+
+	if [[ "$libvirt_throttle_file_lock" == "true" ]]; then
+		features+= ( "libvirt-throttle-file-lock" )
+	fi
+
 	if [[ "$isproto" == "true" ]]; then
 		libvirt_bosh_cpu=
 		prompt_for libvirt_bosh_cpu line \

--- a/hooks/new
+++ b/hooks/new
@@ -296,7 +296,7 @@ libvirt)
 		--default false
 
 	if [[ "$libvirt_throttle_file_lock" == "true" ]]; then
-		features+= ( "libvirt-throttle-file-lock" )
+		features+=( "libvirt-throttle-file-lock" )
 	fi
 
 	if [[ "$isproto" == "true" ]]; then

--- a/hooks/new
+++ b/hooks/new
@@ -590,7 +590,7 @@ libvirt)
 	echo "  libvirt_port:              '$libvirt_port' # must be a string"
 	echo
 	if [[ $isproto == 'true' ]]; then
-		echo "# Proto-BOSH on libvirt"
+		echo "  # Proto-BOSH on libvirt"
 		echo "  #"
 		echo "  libvirt_bosh_cpu:      $libvirt_bosh_cpu"
 		echo "  libvirt_bosh_memory:   $libvirt_bosh_memory"

--- a/hooks/new
+++ b/hooks/new
@@ -307,9 +307,9 @@ libvirt)
 			--default 16384 --label "(disk)"
 	fi
 
-	prompt_for "libvirt/tls:client-cert" --secret-block "What is the libvirt TLS client certificate?"
-	prompt_for "libvirt/tls:client-key" --secret-block "What is the libvirt TLS client private key?"
-	prompt_for "libvirt/tls:server-ca" --secret-block "What is the libvirt TLS server CA?"
+	prompt_for "libvirt/tls:client-cert" secret-block "What is the libvirt TLS client certificate?"
+	prompt_for "libvirt/tls:client-key" secret-block "What is the libvirt TLS client private key?"
+	prompt_for "libvirt/tls:server-ca" secret-block "What is the libvirt TLS server CA?"
 
 esac
 

--- a/hooks/new
+++ b/hooks/new
@@ -59,8 +59,9 @@ prompt_for iaas "select" \
 	-o '[aws]       Amazon Web Services'   \
 	-o '[azure]     Microsoft Azure'       \
 	-o '[google]    Google Cloud Platform' \
-	-o '[openstack] OpenStack' \
-	-o '[warden]    BOSH Warden'
+	-o '[openstack] OpenStack'             \
+	-o '[warden]    BOSH Warden'           \
+	-o '[libvirt]   libvirt'
 
 features=()
 aws_iam_profile_name=
@@ -267,6 +268,49 @@ openstack)
 			'What AZ will the BOSH Director be placed in?'
 	fi
 	;;
+
+libvirt)
+	libvirt_network_name=
+	prompt_for libvirt_network_name line \
+		"What is the libvirt network name?" \
+		--default bosh --label "(network)"
+
+	libvirt_storage_pool_name=
+	prompt_for libvirt_storage_pool_name line \
+		"What is the libvirt storage pool name?" \
+		--default bosh --label "(storage pool)"
+
+	libvirt_host=
+	prompt_for libvirt_host line \
+		"What is the libvirt host name?" 
+
+	libvirt_port=
+	prompt_for libvirt_port line \
+		"What is the libvirt port?" \
+		--default 16514 \
+		--validation port
+
+	if [[ "$isproto" == "true" ]]; then
+		libvirt_bosh_cpu=
+		prompt_for libvirt_bosh_cpu line \
+			"How many vCPUs should BOSH be given?" \
+			--default 2 --label "(cpu)"
+
+		libvirt_bosh_memory=
+		prompt_for libvirt_bosh_memory line \
+			"How much memory should the BOSH VM have?" \
+			--default 4096 --label "(memory)"
+
+		libvirt_bosh_disk=
+		prompt_for libvirt_bosh_disk line \
+			"How much ephemeral disk should the BOSH VM be given?" \
+			--default 16384 --label "(disk)"
+	fi
+
+	prompt_for "libvirt/tls:client-cert" --secret-block "What is the libvirt TLS client certificate?"
+	prompt_for "libvirt/tls:client-key" --secret-block "What is the libvirt TLS client private key?"
+	prompt_for "libvirt/tls:server-ca" --secret-block "What is the libvirt TLS server CA?"
+
 esac
 
 blobstore=
@@ -533,6 +577,26 @@ openstack)
 		echo
 	fi
 	;;
+
+libvirt)
+	echo "  # BOSH on libvirt"
+	echo "  #"
+	echo "  # Libvirt credentials are stored in the Vault at"
+	echo "  #   ${GENESIS_SECRETS_BASE}libvirt/tls"
+	echo "  #"
+	echo "  libvirt_network_name:      $libvirt_network_name"
+	echo "  libvirt_storage_pool_name: $libvirt_storage_pool_name"
+	echo "  libvirt_host:              $libvirt_host"
+	echo "  libvirt_port:              '$libvirt_port' # must be a string"
+	echo
+	if [[ $isproto == 'true' ]]; then
+		echo "# Proto-BOSH on libvirt"
+		echo "  #"
+		echo "  libvirt_bosh_cpu:      $libvirt_bosh_cpu"
+		echo "  libvirt_bosh_memory:   $libvirt_bosh_memory"
+		echo "  libvirt_bosh_disk:     $libvirt_bosh_disk"
+		echo
+	fi
 
 esac
 

--- a/kit.yml
+++ b/kit.yml
@@ -183,6 +183,10 @@ credentials:
     openstack/ssh: ssh 2048
   openstack-cpi: *openstack
 
+  libvirt: &libvirt
+    libvirt/ssh: ssh 2048
+  libvirt-cpi: *libvirt
+
   +internal-blobstore:
     blobstore/agent:
       password: random 64 fixed

--- a/overlay/addons/libvirt-cpi.yml
+++ b/overlay/addons/libvirt-cpi.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: libvirt-bosh-cpi
-    url: https://github.com/a2geek/libvirt-bosh-cpi/releases/download/v4/libvirt-bosh-cpi.tgz
-    version: v4
-    sha1: dc2836c4ef7cc58608bcdba530e5dbb9858488a9
+    url: https://github.com/a2geek/libvirt-bosh-cpi/releases/download/v4.1/libvirt-bosh-cpi.tgz
+    version: v4.1
+    sha1: 5014f84f0190097475268087f2e4b131f62fd0f0
 
 # Configure Bosh VM size
 - type: replace

--- a/overlay/addons/libvirt-cpi.yml
+++ b/overlay/addons/libvirt-cpi.yml
@@ -1,0 +1,90 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: libvirt-bosh-cpi
+    url: https://github.com/a2geek/libvirt-bosh-cpi/releases/download/v4/libvirt-bosh-cpi.tgz
+    version: v4
+    sha1: dc2836c4ef7cc58608bcdba530e5dbb9858488a9
+
+# Configure Bosh VM size
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties?
+  value:
+    cpu: ((libvirt_bosh_cpu))
+    memory: ((libvirt_bosh_memory))
+    ephemeral_disk: ((libvirt_bosh_disk))
+
+# Add CPI job
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value: &cpi_job
+    name: libvirt_cpi
+    release: libvirt-bosh-cpi
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/cpi_job?
+  value: libvirt_cpi
+
+- type: replace
+  path: /cloud_provider/template?
+  value: *cpi_job
+
+# This is for rendering within the VM once stood up
+- type: replace
+  path: /instance_groups/name=bosh/properties/libvirt_cpi?/agent?
+  value:
+    mbus: nats://nats:((nats_password))@((internal_ip)):4222
+    blobstore:
+      provider: dav
+      options:
+        endpoint: http://((internal_ip)):25250
+        user: agent
+        password: ((blobstore_agent_password))
+- type: replace
+  path: /instance_groups/name=bosh/properties/libvirt_cpi?/log_level?
+  value: ((cpi_log_level))
+
+# This is for initial standup of VM (bootstrap?)
+- type: replace
+  path: /cloud_provider/properties/libvirt_cpi?/agent?
+  value:
+    mbus: "https://mbus:((mbus_bootstrap_password))@0.0.0.0:6868"
+    blobstore:
+      provider: local
+      options:
+        blobstore_path: /var/vcap/micro_bosh/data/cache
+- type: replace
+  path: /cloud_provider/properties/libvirt_cpi?/log_level?
+  value: ((cpi_log_level))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: vm_ssh_key
+    type: ssh
+# This is for rendering within the VM once stood up
+- type: replace
+  path: /instance_groups/name=bosh/properties/libvirt_cpi?/vm_ssh_key?
+  value: ((vm_ssh_key))
+# This is for initial standup of VM (bootstrap?)
+- type: replace
+  path: /cloud_provider/properties/libvirt_cpi?/vm_ssh_key?
+  value: ((vm_ssh_key))
+
+# This is for rendering within the VM once stood up
+- type: replace
+  path: /instance_groups/name=bosh/properties/libvirt_cpi?/settings?
+  value: &libvirt_settings
+    storage_pool_name: ((libvirt_storage_pool_name))
+    network_name: ((libvirt_network_name))
+    network_dhcp_ip: ((libvirt_network_dhcp_ip))
+    disk_device: ((libvirt_disk_device))
+    storage_volume: ((libvirt_storage_volume))
+    manual_network_interface: ((libvirt_manual_network_interface))
+    vm_domain: ((libvirt_vm_domain))
+
+# This is for initial standup of VM (bootstrap?)
+- type: replace
+  path: /cloud_provider/properties/libvirt_cpi?/settings?
+  value: *libvirt_settings

--- a/overlay/addons/libvirt-openstack-stemcell.yml
+++ b/overlay/addons/libvirt-openstack-stemcell.yml
@@ -1,0 +1,21 @@
+# Setup for Openstack stemcell
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=621.75
+    sha1: abec2fa6dd240e4f8ed4d3d391d8d96249bde873
+
+# This is for rendering within the VM once stood up
+- type: replace
+  path: /instance_groups/name=bosh/properties/libvirt_cpi?/stemcell?
+  value: &stemcell_settings
+    formats: [ "openstack-qcow2", "openstack-raw" ]
+    type: ConfigDrive
+    label: "config-2"
+    metadata_path: "ec2/latest/meta-data.json"
+    userdata_path: "ec2/latest/user-data"
+
+# This is for initial standup of VM (bootstrap?)
+- type: replace
+  path: /cloud_provider/properties/libvirt_cpi?/stemcell?
+  value: *stemcell_settings

--- a/overlay/addons/libvirt-throttle-file-lock.yml
+++ b/overlay/addons/libvirt-throttle-file-lock.yml
@@ -1,0 +1,10 @@
+# Enable file-lock mechanism to prevent too many VMs from being spun up.
+- type: replace
+  path: /instance_groups/name=bosh/properties/libvirt_cpi?/throttle?
+  value: &throttle_config
+    name: file-lock
+
+# This is for initial standup of VM (bootstrap?)
+- type: replace
+  path: /cloud_provider/properties/libvirt_cpi?/throttle?
+  value: *throttle_config

--- a/overlay/addons/libvirt-throttle-file-lock.yml
+++ b/overlay/addons/libvirt-throttle-file-lock.yml
@@ -1,10 +1,13 @@
-# Enable file-lock mechanism to prevent too many VMs from being spun up.
-- type: replace
-  path: /instance_groups/name=bosh/properties/libvirt_cpi?/throttle?
-  value: &throttle_config
-    name: file-lock
+# This seems to work for both proto-bosh as well as environmental-bosh.
+# If it causes grief, they likely will need to be split.
 
-# This is for initial standup of VM (bootstrap?)
-- type: replace
-  path: /cloud_provider/properties/libvirt_cpi?/throttle?
-  value: *throttle_config
+# Environmental
+instance_groups:
+- name: bosh
+  properties: &throttle_config
+    libvirt_cpi:
+      throttle: file-lock
+
+# Proto
+cloud_provider:
+  properties: *throttle_config

--- a/overlay/addons/libvirt-throttle-file-lock.yml
+++ b/overlay/addons/libvirt-throttle-file-lock.yml
@@ -6,7 +6,8 @@ instance_groups:
 - name: bosh
   properties: &throttle_config
     libvirt_cpi:
-      throttle: file-lock
+      throttle: 
+        name: file-lock
 
 # Proto
 cloud_provider:

--- a/overlay/addons/libvirt-tls.yml
+++ b/overlay/addons/libvirt-tls.yml
@@ -1,0 +1,17 @@
+# This is for rendering within the VM once stood up
+- type: replace
+  path: /instance_groups/name=bosh/properties/libvirt_cpi?/libvirt?
+  value: &libvirt_connection
+    type: tls
+    host: ((libvirt_host))
+    port: ((libvirt_port))
+    client:
+      certificate: ((libvirt_client_cert))
+      private_key: ((libvirt_client_key))
+    server_ca:
+      certificate: ((libvirt_server_ca))
+
+# This is for initial standup of VM (bootstrap?)
+- type: replace
+  path: /cloud_provider/properties/libvirt_cpi?/libvirt?
+  value: *libvirt_connection

--- a/overlay/cpis/libvirt-proto.yml
+++ b/overlay/cpis/libvirt-proto.yml
@@ -1,0 +1,16 @@
+---
+params:
+  libvirt_bosh_cpu:    (( param "What number of CPUs should BOSH have?" ))
+  libvirt_bosh_memory: (( param "How much memory should BOSH be given?" ))
+  libvirt_bosh_disk:   (( param "How much ephemeral disk should BOSH have?" ))
+
+bosh-variables:
+  libvirt_bosh_cpu:    (( grab params.libvirt_bosh_cpu ))
+  libvirt_bosh_memory: (( grab params.libvirt_bosh_memory ))
+  libvirt_bosh_disk:   (( grab params.libvirt_bosh_disk ))
+
+resource_pools:
+- cloud_properties:
+    cpu: (( grab params.libvirt_bosh_cpu ))
+    memory: (( grab params.libvirt_bosh_memory ))
+    ephemeral_disk: (( grab params.libvirt_bosh_disk ))

--- a/overlay/cpis/libvirt.yml
+++ b/overlay/cpis/libvirt.yml
@@ -7,7 +7,12 @@ params:
   libvirt_client_cert:       (( vault meta.vault "/libvirt/tls:client-cert" ))
   libvirt_client_key:        (( vault meta.vault "/libvirt/tls:client-key" ))
   libvirt_server_ca:         (( vault meta.vault "/libvirt/tls:server-ca" ))
-  vm_ssh_key:                (( vault meta.vault "/libvirt/ssh:public" ))
+
+  # This is mimicking the BOSH variable structure
+  vm_ssh_key:
+    public_key:              (( vault meta.vault "/libvirt/ssh:public" ))
+    public_key_fingerprint:  (( vault meta.vault "/libvirt/ssh:fingerprint" ))
+    private_key:             (( vault meta.vault "/libvirt/ssh:private" ))
 
 bosh-variables:
   libvirt_network_name:      (( grab params.libvirt_network_name ))

--- a/overlay/cpis/libvirt.yml
+++ b/overlay/cpis/libvirt.yml
@@ -7,7 +7,7 @@ params:
   libvirt_client_cert:       (( vault meta.vault "/libvirt/tls:client-cert" ))
   libvirt_client_key:        (( vault meta.vault "/libvirt/tls:client-key" ))
   libvirt_server_ca:         (( vault meta.vault "/libvirt/tls:server-ca" ))
-  vm_ssh_key:                (( vault meta.vault "/libvirt/ssh" ))
+  vm_ssh_key:                (( vault meta.vault "/libvirt/ssh:public" ))
 
 bosh-variables:
   libvirt_network_name:      (( grab params.libvirt_network_name ))

--- a/overlay/cpis/libvirt.yml
+++ b/overlay/cpis/libvirt.yml
@@ -7,6 +7,7 @@ params:
   libvirt_client_cert:       (( vault meta.vault "/libvirt/tls:client-cert" ))
   libvirt_client_key:        (( vault meta.vault "/libvirt/tls:client-key" ))
   libvirt_server_ca:         (( vault meta.vault "/libvirt/tls:server-ca" ))
+  vm_ssh_key:                (( vault meta.vault "/libvirt/ssh" ))
 
 bosh-variables:
   libvirt_network_name:      (( grab params.libvirt_network_name ))
@@ -16,6 +17,10 @@ bosh-variables:
   libvirt_client_cert:       (( grab params.libvirt_client_cert ))
   libvirt_client_key:        (( grab params.libvirt_client_key ))
   libvirt_server_ca:         (( grab params.libvirt_server_ca ))
+  vm_ssh_key:                (( grab params.vm_ssh_key ))
+
+  # NONE, ERROR, WARN, INFO, DEBUG
+  cpi_log_level: DEBUG
 
   # Rendered with Go text templates, see https://golang.org/pkg/text/template/
   # These can be changed for differering characteristings. This seems to be the "best" general fit.

--- a/overlay/cpis/libvirt.yml
+++ b/overlay/cpis/libvirt.yml
@@ -1,0 +1,72 @@
+---
+params:
+  libvirt_network_name:      (( param "What is the libvirt network name?" ))
+  libvirt_storage_pool_name: (( param "What is the libvirt storage pool name?" ))
+  libvirt_host:              (( param "What is the libvirt host?" ))
+  libvirt_port:              (( param "What is the libvirt port?" ))
+  libvirt_client_cert:       (( vault meta.vault "/libvirt/tls:client-cert" ))
+  libvirt_client_key:        (( vault meta.vault "/libvirt/tls:client-key" ))
+  libvirt_server_ca:         (( vault meta.vault "/libvirt/tls:server-ca" ))
+
+bosh-variables:
+  libvirt_network_name:      (( grab params.libvirt_network_name ))
+  libvirt_storage_pool_name: (( grab params.libvirt_storage_pool_name ))
+  libvirt_host:              (( grab params.libvirt_host ))
+  libvirt_port:              (( grab params.libvirt_port ))
+  libvirt_client_cert:       (( grab params.libvirt_client_cert ))
+  libvirt_client_key:        (( grab params.libvirt_client_key ))
+  libvirt_server_ca:         (( grab params.libvirt_server_ca ))
+
+  # Rendered with Go text templates, see https://golang.org/pkg/text/template/
+  # These can be changed for differering characteristings. This seems to be the "best" general fit.
+  # An alternative for QEMU is [here](https://github.com/a2geek/libvirt-bosh-cpi/blob/master/manifests/libvirt-qemu-vars.yml).
+  # Libvirt XML documentation is [here](https://libvirt.org/format.html). For instance, [domains](https://libvirt.org/formatdomain.html) are VMs.
+  libvirt_network_dhcp_ip: |
+    <host name='{{.VmName}}' mac='{{.MacAddress}}' ip='{{.IpAddress}}'/>
+  libvirt_disk_device: |
+    <disk type='file' device='{{.Device}}'>
+      <driver name='qemu' type='raw' cache='none'/>
+      <source file='{{.TargetPath}}'/>
+      <target dev='{{.TargetDevice}}' bus='{{.TargetBus}}'/>
+    </disk>
+  libvirt_storage_volume: |
+    <volume>
+      <name>{{.Name}}</name>
+      <allocation unit="G">0</allocation>
+      <capacity unit="{{.Unit}}">{{.Size}}</capacity>
+    </volume>
+  libvirt_manual_network_interface: |
+    <interface type='network'>
+      <source network='{{.NetworkName}}'/>
+      <target dev='vnet0'/>
+      <mac address='{{.MacAddress}}'/>
+      <model type='virtio'/>
+      <alias name='net0'/>
+    </interface>
+  libvirt_vm_domain: |
+    <domain type='kvm'>
+      <name>{{.Name}}</name>
+      <uuid>{{.UUID}}</uuid>
+      <memory unit='MiB'>{{.Memory}}</memory>
+      <vcpu>{{.CPU}}</vcpu>
+      <os>
+        <type>hvm</type>
+        <boot dev='hd'/>
+      </os>
+      <features>
+        <acpi/>
+        <apic/>
+        <vmport state='off'/>
+      </features>
+      <on_poweroff>destroy</on_poweroff>
+      <on_reboot>restart</on_reboot>
+      <on_crash>restart</on_crash>
+      <devices>
+        <serial type='pty'>
+          <target port='0'/>
+        </serial>
+        <console type='pty'>
+          <target type='serial' port='0'/>
+        </console>
+      </devices>
+    </domain>


### PR DESCRIPTION
This PR adds the libvirt CPI to the kit. Looking for commentary on *if* this is something that should be part of the primary bosh kit or not. There could potentially be a secondary bosh kit just for libvirt.

It can deploy a proto-bosh as well as an environmental bosh.