### PR TITLE
Revert changing os-conf release to opsfile style

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,2 +1,17 @@
+# Bug Fixes
 
+- Fixes for rutime addon:
+
+  1. Use overlay style for including os-conf release because it gets concated
+     into an existing overlay style file, which was incompatible with its
+     previous operator style.
+
+  2. Improve runtime-config interface, to give better feedback for runtime
+     uploads.
+
+  3. Delete genesis.ops-access runtime if both netop-access and sysop-access
+     features are not present (instead of uploading an empty runtime config)
+
+  4. Fix exclude of genesis-local-users runtime job (it was in the wrong
+     level, and therefore uneffective.
 

--- a/ci/tasks/get-latest-bosh-deployment/task
+++ b/ci/tasks/get-latest-bosh-deployment/task
@@ -37,13 +37,11 @@ url=$( bosh int bosh-deployment/bosh.yml -o bosh-deployment/jumpbox-user.yml --p
 sha1=$( bosh int bosh-deployment/bosh.yml -o bosh-deployment/jumpbox-user.yml --path /releases/name=os-conf/sha1 )
 
 cat > overlay/releases/os-conf.yml <<YML
-- type: replace
-  path: /releases?/name=${release_name}?
-  value:
-    name: ${release_name}
-    version: ${release_version}
-    url: ${url}
-    sha1: ${sha1}
+releases:
+- name: ${release_name}
+  version: ${release_version}
+  url: ${url}
+  sha1: ${sha1}
 YML
 
 DNS=$(bosh int bosh-deployment/runtime-configs/dns.yml --path /releases)

--- a/hooks/addon-runtime-config
+++ b/hooks/addon-runtime-config
@@ -128,13 +128,13 @@ generate_ops_access_runtime() {
   cat <<EOF
 addons:
 - name: genesis-local-users
+  exclude:
+    jobs:
+    - name: user_add
+      release: os-conf
   jobs:
   - name:    user_add
     release: os-conf
-    exclude:
-      jobs:
-      - name: user_add
-        release: os-conf
     properties:
       persistent_homes: true
       users:

--- a/hooks/addon-runtime-config
+++ b/hooks/addon-runtime-config
@@ -40,15 +40,29 @@ upload_runtime_config() {
   BOSH_CLIENT_SECRET="$(echo "$exodus" | jq -r '.admin_password')" \
   bosh update-runtime-config --tty --name="${name}" <(echo "$contents")
 }
+remove_runtime_config() {
+  name="${1:-default}"
+  export BOSH_ENVIRONMENT="$(echo "$exodus" | jq -r '.url')"
+  export BOSH_CA_CERT="$(echo "$exodus" | jq -r '.ca_cert')"
+  export BOSH_CLIENT="$(echo "$exodus" | jq -r '.admin_username')"
+  export BOSH_CLIENT_SECRET="$(echo "$exodus" | jq -r '.admin_password')"
+  if [[ -n "$(bosh configs --type=runtime --name="$name")" ]] ; then
+    describe >&2 "" "Removing existing '$name' runtime:" "- ---"
+    get_runtime_config "$name" 2>&1 | sed -e 's/\(.*\)/- \1/' >&2
+    echo >&2 ''
+    bosh delete-config --type=runtime --name="$name"
+  fi
+}
 
-get_default_runtime() {
+get_runtime_config() {
+   name="${1:-default}"
    (set +e
    BOSH_ENVIRONMENT="$(echo "$exodus" | jq -r '.url')" \
    BOSH_CA_CERT="$(echo "$exodus" | jq -r '.ca_cert')" \
    BOSH_CLIENT="$(echo "$exodus" | jq -r '.admin_username')" \
    BOSH_CLIENT_SECRET="$(echo "$exodus" | jq -r '.admin_password')" \
-   bosh config --type=runtime --name=default ) \
-   | sed -e 's/\s+//' | sed '/^$/d' | spruce merge
+   bosh config --type=runtime --name="$name" ) \
+   | tail -n+5 | sed -e 's/\s\+$//' | spruce merge
 }
 
 generate_dns_runtime() {
@@ -107,7 +121,7 @@ EOF
 
 generate_ops_access_runtime() {
   if ! printf '%s\n' "${features[@]}" | grep -q '^\(net\|sys\)op-access$' ; then
-    echo "--- {}"
+    echo ""
     return 0
   fi
 
@@ -148,7 +162,7 @@ addons:
 - name: bosh-dns
 EOF
     ) \
-    <(get_default_runtime) \
+    <(get_runtime_config) \
     <( cat <<'EOF'
 addons:
 - (( delete "genesis-local-users" ))
@@ -190,14 +204,22 @@ if [[ -n "$dryrun" ]] ; then
       describe "" \
         "Operator Access Runtime Config" \
         "------------------------------"
-      generate_dns_runtime | spruce merge
+      generate_ops_access_runtime | spruce merge
     fi
   fi
   echo
   exit 0
 elif [[ -n "$default" ]] ; then
+  describe >&2 "Uploading runtime - this will replace your existing default runtime"
   upload_runtime_config default "$(generate_merged_default_runtime)"
 else
+  describe >&2 "Uploading 'genesis.bosh-dns' runtime"
   upload_runtime_config "genesis.bosh-dns" "$(generate_dns_runtime | spruce merge)"
-  upload_runtime_config "genesis.ops-access" "$(generate_ops_access_runtime | spruce merge)"
+  opsaccess="$(generate_ops_access_runtime)"
+  if [[ -z "$opsaccess" ]] ; then
+    remove_runtime_config "genesis.ops-access"
+  else
+    describe >&2 "Uploading 'genesis.ops-access' runtime"
+    upload_runtime_config "genesis.ops-access" "$(generate_ops_access_runtime | spruce merge)"
+  fi
 fi

--- a/hooks/addon-runtime-config
+++ b/hooks/addon-runtime-config
@@ -177,7 +177,7 @@ done
 if [[ -n "$dryrun" ]] ; then
   if [[ -n "$default" ]] ; then
     describe "" \
-      "BOSH DNS Runtime Config" \
+      "Runtime Config" \
       "-----------------------"
     generate_merged_default_runtime
   else
@@ -188,8 +188,8 @@ if [[ -n "$dryrun" ]] ; then
 
     if printf '%s\n' "${features[@]}" | grep -q '^\(net\|sys\)op-access$' ; then
       describe "" \
-        "Access Runtime Config" \
-        "---------------------"
+        "Operator Access Runtime Config" \
+        "------------------------------"
       generate_dns_runtime | spruce merge
     fi
   fi

--- a/overlay/releases/os-conf.yml
+++ b/overlay/releases/os-conf.yml
@@ -1,7 +1,5 @@
-- type: replace
-  path: /releases?/name=os-conf?
-  value:
-    name: os-conf
-    version: 22.1.0
-    url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.1.0
-    sha1: 7ef05f6f3ebc03f59ad8131851dbd1abd1ab3663
+releases:
+- name: os-conf
+  version: 22.1.0
+  url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.1.0
+  sha1: 7ef05f6f3ebc03f59ad8131851dbd1abd1ab3663


### PR DESCRIPTION
The previous change to `overlay/releases/os-conf.yml` to change it from overlay style to operator style broke the runtime addon.  This reverts that change.

This also handles the use/non-use of the ops user runtime better, by deleting it if not used instead of uploading an empty config, and putting headings on which config was being uploaded prior to asking to confirm.

Also, one minor textual clean up in the runtime addon to change "Access" to "Operator Access" for clarity