### PR TITLE
Fix implementation of `bosh-dns-healthcheck`

### DIFF
--- a/hooks/addon-runtime-config
+++ b/hooks/addon-runtime-config
@@ -82,7 +82,7 @@ fi
       cache:
         enabled: $params_dns_cache
 EOF
-  if printf '%s\n' "${features[@]}" | grep -q '^dns-healthcheck$'; then
+  if printf '%s\n' "${features[@]}" | grep -q '^bosh-dns-healthcheck$'; then
     cat <<EOF
       health:
         enabled: true

--- a/kit.yml
+++ b/kit.yml
@@ -85,7 +85,7 @@ certificates:
         names:
         - ${params.static_ip}
 
-  dns-healthcheck:
+  bosh-dns-healthcheck:
     dns_healthcheck_tls:
       ca:
         valid_for: ${params.ca_validity_period}


### PR DESCRIPTION
Per the MANUAL.md, the feature is named `bosh-dns-healthcheck`. However,
`genesis check-secrets` nor the `runtime-config` addon have any affect
when the feature is enabled as such.

This PR fixes it by properly naming the feature in the `kit.yml` as well
as the `hooks/addon-runtime-config`.