### PR TITLE
IAM instance profile for non-proto

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -384,7 +384,9 @@ Other parameters included in the environment file under `params`:
 * `s3_blobstore_bucket`
 * `s3_blobstore_region`
 
-To authenticate with the s3 blobstore using IAM instance profiles, activate the `s3-blobstore-iam-instance-profile` feature as well. If done, the `access_key` and `secret_key` values are no longer required in the Vault. Keep in mind that all VMs deployed by BOSH must also be able to authenticate to the blobstore, so an IAM Instance Profile authorized to get secrets from the S3 blobstore must be associated with every VM deployed by this BOSH, including compilation VMs.
+To authenticate with the s3 blobstore using IAM instance profiles, activate the `s3-blobstore-iam-instance-profile` feature as well. If done, the `access_key` and `secret_key` values are no longer required in the Vault. Keep in mind that all VMs deployed by BOSH must also be able to authenticate to the blobstore, so an IAM Instance Profile authorized to get secrets from the S3 blobstore must be associated with every VM deployed by this BOSH, including compilation VMs. To do so,Add below param to non-proto director which attaches IAM instance profile to the vm's created by it.
+    **Required**
+  - `aws_s3_iam_instance_profile` - The  IAM instance profile to associate with the VMs created by non-proto directors for accessing the S3 blobstore
 
 The `s3_blobstore` feature can be used regardless of the Cloud Infrastructure being used, but the `s3-blobstore-iam-instance-profile` feature can only be used if the BOSH director is deployed with the `aws` feature.
 

--- a/overlay/addons/s3-blobstore-iam-profile.yml
+++ b/overlay/addons/s3-blobstore-iam-profile.yml
@@ -1,3 +1,5 @@
+params:
+  aws_s3_iam_instance_profile: (( param "Please provide the IAM instance profile to associate with the VMs for accessing the S3 blobstore"))
 ---
 - type: remove
   path: /instance_groups/name=bosh/properties/blobstore/access_key_id
@@ -26,3 +28,7 @@
 
 - type: remove
   path: /bosh-variables/s3-secret-access-key
+
+- type: replace
+  path: /properties?/aws?/default_iam_instance_profile
+  value: (( grab params.aws_s3_iam_instance_profile ))


### PR DESCRIPTION
`aws_s3_iam_instance_profile` param helps the non-proto director to assign the IAM instance profile for the vm's created by it . 