### PR TITLE
ocfp kit changes for bringing in nats2 info to older bosh

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -47,6 +47,9 @@ merge=( bosh-deployment/bosh.yml
         bosh-deployment/misc/proxy.yml
         bosh-deployment/misc/trusted-certs.yml )
 
+#NOTE: This is until bosh-deployment is upgraded:
+merge+=( "overlay/nats2.yml" )
+
 # Check for ops features
 declare -a features
 features=()

--- a/kit.yml
+++ b/kit.yml
@@ -137,6 +137,8 @@ credentials:
       password: random 64
     nats:
       password: random 64 fixed
+    nats_sync_password:
+      password: random 64 fixed
     registry:
       password: random 64 fixed
 

--- a/overlay/base.yml
+++ b/overlay/base.yml
@@ -25,6 +25,7 @@ bosh-variables:
     certificate: (( vault meta.vault "/nats/health/monitor:certificate" ))
     private_key: (( vault meta.vault "/nats/health/monitor:key" ))
   nats_password: (( vault meta.vault "/nats:password" ))
+  nats_sync_password: (( vault meta.vault "/nats_sync_password:password" ))
   nats_server_tls:
     ca: (( vault meta.vault "/nats/ca:certificate" ))
     certificate: (( vault meta.vault "/nats/server:certificate" ))

--- a/overlay/nats2.yml
+++ b/overlay/nats2.yml
@@ -1,0 +1,16 @@
+- path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/nats?
+  type: replace
+  value:
+    authorities: bosh.admin
+    authorized-grant-types: client_credentials
+    override: true
+    scope: ""
+    secret: ((nats_sync_password))
+
+- path: /instance_groups/name=bosh/properties/nats/director_account?
+  type: replace
+  value:
+    password: ((nats_sync_password))
+    client_secret: ((nats_sync_password))
+    client_id: nats
+    ca_cert: ((director_ssl.ca))


### PR DESCRIPTION
Changes made to move nats2 info into kit so bosh can rev past `273`