### PR TITLE
Replace duplicated az_map loop with cpi_name_for_az override

### DIFF
--- a/hooks/cloud-config-director.pm
+++ b/hooks/cloud-config-director.pm
@@ -7,7 +7,7 @@ use warnings;
 BEGIN {push @INC, $ENV{GENESIS_LIB} ? $ENV{GENESIS_LIB} : $ENV{HOME}.'/.genesis/lib'}
 use parent qw(Genesis::Hook::CloudConfig::Director);
 
-use Genesis qw/uniq bail/;
+use Genesis qw/bail/;
 use Genesis::Hook::CloudConfig::Helpers qw/gigabytes megabytes/;
 
 use JSON::PP;
@@ -19,16 +19,17 @@ sub init {
 	return $obj;
 }
 
-# _cpi_name_for_az - Resolves the CPI name to use for a given AZ key {{{
-sub _cpi_name_for_az {
-	my ($self, $az_name) = @_;
+# cpi_name_for_az - Resolves the CPI name to use for a given AZ key {{{
+sub cpi_name_for_az {
+	my ($self, $az_key, $az_data) = @_;
 
-	# Resolve a per-AZ CPI name from bosh-configs.director-cpi.az_map when
+	# Overrides the base extension point (Genesis::Hook::CloudConfig) to
+	# resolve a per-AZ CPI name from bosh-configs.director-cpi.az_map when
 	# present; otherwise fall through to the existing single-CPI-per-director
 	# default, so every env that doesn't declare az_map renders byte-identical
 	# cloud-config to today.
 	my $az_map = $self->env->lookup('bosh-configs.director-cpi.az_map', {});
-	return $az_map->{$az_name} if ref($az_map) eq 'HASH' && exists $az_map->{$az_name};
+	return $az_map->{$az_key} if ref($az_map) eq 'HASH' && defined($az_key) && exists $az_map->{$az_key};
 	return $self->cpi_name;
 }
 
@@ -63,37 +64,14 @@ sub _validate_az_map_keys {
 }
 
 # }}}
-# build_az_definitions - Overrides base to allow per-AZ CPI selection via az_map {{{
+# build_az_definitions - Validates az_map, then defers to the base loop {{{
 sub build_az_definitions {
 	my ($self, %options) = @_;
 
-	# Same shape/loop as the base class (Genesis::Hook::CloudConfig::Director),
-	# except the injected `cpi:` per AZ comes from _cpi_name_for_az($az_name)
-	# instead of the base's single $self->cpi_name for every entry. $az_name is
-	# available here because this method owns the loop over get_available_azs
-	# directly, unlike _az_definition_for, which only ever receives the per-AZ
-	# data hashref, never the original key.
-	#
-	# DRIFT RISK: this duplicates the loop body of
-	# Genesis::Hook::CloudConfig::Director::build_az_definitions (genesis
-	# lib/Genesis/Hook/CloudConfig/Director.pm).  Changes to the base loop
-	# (AZ filtering, sorting, definition shape) will NOT reach this kit;
-	# re-diff against the base method whenever upgrading Genesis, until the
-	# base grows a per-AZ cpi extension point and this override can shrink
-	# to just _cpi_name_for_az.
-	my $prefix = delete($options{prefix}) // '';
-
-	my @azs = ();
-	my $azs = $self->get_available_azs;
-	$self->_validate_az_map_keys($azs) if $self->cpi_enabled;
-	for my $az_name (keys %$azs) {
-		next unless $azs->{$az_name}{name};
-		my $config = $self->_az_definition_for($azs->{$az_name}, %options);
-		$config->{cpi} = $self->_cpi_name_for_az($az_name) if $self->cpi_enabled;
-		push @azs, $config;
-	}
-	my @results = uniq sort {$a->{name} cmp $b->{name}} @azs;
-	return wantarray ? @results : \@results;
+	# The base loop injects per-AZ `cpi:` via our cpi_name_for_az override;
+	# this wrapper only adds the fail-loud az_map key check before it runs.
+	$self->_validate_az_map_keys(scalar $self->get_available_azs) if $self->cpi_enabled;
+	return $self->SUPER::build_az_definitions(%options);
 }
 
 # }}}

--- a/spec/spec.t
+++ b/spec/spec.t
@@ -84,8 +84,9 @@ test_env(name => 'pve-userpass-auth',     cloud_config => 'pve');
 # pve multi-AZ CPI plumbing (P2-T1): bosh-configs.director-cpi.{cpis,default,
 # az_map} schema-acceptance regression -- proves the new env-file keys pass
 # through env-file processing without altering the rendered director
-# manifest.  The per-AZ cpi-selection logic itself (build_az_definitions /
-# _cpi_name_for_az) is covered by spec/unit/cloud-config-director-az-map.t,
+# manifest.  The per-AZ cpi-selection logic itself (the kit's
+# cpi_name_for_az override plus the base-class AZ-definition loop) is
+# covered by spec/unit/cloud-config-director-az-map.t,
 # not reachable here -- see that file's header comment for why.
 # The per-AZ cpi entries reference director-credhub paths for their API
 # tokens; the validator has no credhub, so supply them as literals via the

--- a/spec/unit/cloud-config-director-az-map.t
+++ b/spec/unit/cloud-config-director-az-map.t
@@ -1,18 +1,18 @@
 #!/usr/bin/env perl
-# Unit tests for P2-T1 (_cpi_name_for_az / overridden build_az_definitions)
+# Unit tests for per-AZ CPI routing (cpi_name_for_az / _validate_az_map_keys)
 # in hooks/cloud-config-director.pm.
 #
-# hooks/cloud-config-director.pm's build_az_definitions is not reachable
+# hooks/cloud-config-director.pm's AZ-definition path is not reachable
 # through genesis check/manifest/yamls -- Genesis only invokes it via
 # run_hook('cloud-config', purpose => 'director'), which is called
 # exclusively from Genesis::Hook::PostDeploy::update_director_network_config
 # after a live, successful `bosh create-env`/director deploy. It cannot be
 # exercised through spec/spec.t's genesis-manifest pipeline. This file loads
-# the real hook module directly and drives its two new/changed methods
-# against thin test doubles for the base-class collaborators (env, cpi_name,
-# cpi_enabled, get_available_azs, _az_definition_for), so the code under
-# test -- build_az_definitions, _cpi_name_for_az, and _validate_az_map_keys
-# -- runs unmodified.
+# the real hook module directly and drives it against thin test doubles for
+# the env-side collaborators (env, cpi_name, cpi_enabled,
+# get_available_azs), so the code under test -- the kit's cpi_name_for_az
+# override, _validate_az_map_keys, and the base class's
+# build_az_definitions/_az_definition_for loop -- runs unmodified.
 #
 # get_available_azs keys used below are the OCFP vault AZ key names
 # (net/azs/*, e.g. pvea, pved) -- the real production shape. Each AZ's
@@ -65,10 +65,10 @@ sub lookup {
 
 package Test::FakeCloudConfigDirector;
 
-# Inherit the real hook module under test -- build_az_definitions,
-# _cpi_name_for_az, and _validate_az_map_keys are NOT overridden here, so
-# they run as shipped in hooks/cloud-config-director.pm. Only base-class
-# collaborators are stubbed.
+# Inherit the real hook module under test -- cpi_name_for_az,
+# _validate_az_map_keys, and the inherited base-class
+# build_az_definitions/_az_definition_for loop are NOT overridden here, so
+# they run as shipped. Only the env-side collaborators are stubbed.
 our @ISA = ('Genesis::Hook::CloudConfigDirector::BOSH');
 
 sub new {
@@ -85,13 +85,6 @@ sub env                { $_[0]->{env} }
 sub cpi_enabled         { $_[0]->{cpi_enabled} }
 sub cpi_name            { $_[0]->{base_cpi} }
 sub get_available_azs   { $_[0]->{azs} }
-
-# Mirrors the real base class's shape (Hook/CloudConfig.pm:1595-1603) minus
-# the cpi assignment, which build_az_definitions overwrites regardless.
-sub _az_definition_for {
-	my ($self, $az, %options) = @_;
-	return { name => $az->{name}, cloud_properties => {} };
-}
 
 package main;
 
@@ -116,8 +109,8 @@ subtest 'az_map absent falls back to base cpi_name (byte-identical to baseline)'
 		env      => $env,
 		base_cpi => 'pve-bosh.pve.pve',
 		azs      => {
-			pvea => { name => 'pve-multi-az-z1' },
-			pved => { name => 'pve-multi-az-z4' },
+			pvea => { name => 'pve-multi-az-z1', cloud_properties => '{}' },
+			pved => { name => 'pve-multi-az-z4', cloud_properties => '{}' },
 		},
 	);
 	my @azs = $hook->build_az_definitions;
@@ -149,8 +142,8 @@ subtest 'az_map keyed by vault AZ keys resolves distinct per-AZ cpi names' => su
 		env      => $env,
 		base_cpi => 'pve-bosh.pve.pve',
 		azs      => {
-			pvea => { name => 'pve-multi-az-z1' },
-			pved => { name => 'pve-multi-az-z4' },
+			pvea => { name => 'pve-multi-az-z1', cloud_properties => '{}' },
+			pved => { name => 'pve-multi-az-z4', cloud_properties => '{}' },
 		},
 	);
 	my @azs = $hook->build_az_definitions;
@@ -175,8 +168,8 @@ subtest 'az_map keyed by a rendered -zN name (not a vault AZ key) triggers a fat
 		env      => $env,
 		base_cpi => 'pve-bosh.pve.pve',
 		azs      => {
-			pvea => { name => 'pve-multi-az-z1' },
-			pved => { name => 'pve-multi-az-z4' },
+			pvea => { name => 'pve-multi-az-z1', cloud_properties => '{}' },
+			pved => { name => 'pve-multi-az-z4', cloud_properties => '{}' },
 		},
 	);
 	my @azs;
@@ -206,8 +199,8 @@ subtest 'az not covered by az_map falls back to base cpi_name' => sub {
 		env      => $env,
 		base_cpi => 'pve-bosh.pve.pve',
 		azs      => {
-			pvea => { name => 'pve-multi-az-z1' },
-			pved => { name => 'pve-multi-az-z4' },
+			pvea => { name => 'pve-multi-az-z1', cloud_properties => '{}' },
+			pved => { name => 'pve-multi-az-z4', cloud_properties => '{}' },
 		},
 	);
 	my @azs = $hook->build_az_definitions;
@@ -225,20 +218,38 @@ subtest 'cpi_enabled false suppresses the cpi key entirely, az_map or not' => su
 	my $hook = Test::FakeCloudConfigDirector->new(
 		env         => $env,
 		cpi_enabled => 0,
-		azs         => { pvea => { name => 'pve-multi-az-z1' } },
+		azs         => { pvea => { name => 'pve-multi-az-z1', cloud_properties => '{}' } },
 	);
 	my @azs = $hook->build_az_definitions;
 	ok(!exists $azs[0]{cpi}, 'no cpi key set when cpi_enabled is false');
 };
 
+# --- cpi_name_for_az overrides the base extension point directly -------
+subtest 'cpi_name_for_az override resolves az_map by vault key' => sub {
+	my $env = Test::FakeEnv->new(
+		'bosh-configs' => {
+			'director-cpi' => { 'az_map' => { pvea => 'pve-cpi' } },
+		},
+	);
+	my $hook = Test::FakeCloudConfigDirector->new(env => $env, base_cpi => 'pve-bosh.pve.pve');
+	is(
+		$hook->cpi_name_for_az('pvea', { name => 'pve-multi-az-z1' }), 'pve-cpi',
+		'mapped vault key resolves through the public cpi_name_for_az hook',
+	);
+	is(
+		$hook->cpi_name_for_az('pved', { name => 'pve-multi-az-z4' }), 'pve-bosh.pve.pve',
+		'unmapped vault key falls back to base cpi_name',
+	);
+};
+
 # --- Defensive: malformed az_map value doesn't die, just falls back ----
-subtest '_cpi_name_for_az defensive: non-hash az_map value falls back safely' => sub {
+subtest 'cpi_name_for_az defensive: non-hash az_map value falls back safely' => sub {
 	my $env = Test::FakeEnv->new(
 		'bosh-configs' => { 'director-cpi' => { 'az_map' => 'not-a-hash' } },
 	);
 	my $hook = Test::FakeCloudConfigDirector->new(env => $env, base_cpi => 'pve-bosh.pve.pve');
 	is(
-		$hook->_cpi_name_for_az('pvea'), 'pve-bosh.pve.pve',
+		$hook->cpi_name_for_az('pvea', undef), 'pve-bosh.pve.pve',
 		'malformed az_map falls back to base cpi_name, does not die',
 	);
 };


### PR DESCRIPTION
Kit side of FWT-1032 (https://fivetwenty.atlassian.net/browse/FWT-1032).
Companion to RubidiumStudios/genesis#3, which adds the
`cpi_name_for_az($az_key, $az_data)` extension point to
`Genesis::Hook::CloudConfig`.

## What

- Drops the ~30-line duplicated `build_az_definitions` loop (the DRIFT
  RISK block) from `hooks/cloud-config-director.pm`.
- Overrides just `cpi_name_for_az`: resolves
  `bosh-configs.director-cpi.az_map` by vault AZ key (net/azs/* names),
  falling back to the single `cpi_name` when the key is unmapped or the
  map is absent/malformed.
- Keeps a thin `build_az_definitions` wrapper solely for the fail-loud
  unknown-az_map-key validation before deferring to the base loop.

## Tests

`spec/unit/cloud-config-director-az-map.t` reworked to drive the real
base-class loop (no more stubbed `_az_definition_for`): absent az_map is
byte-identical to single-CPI baseline, vault-keyed map resolves distinct
per-AZ CPIs, rendered `-zN` keys bail loudly, partial maps fall back,
`cpi_enabled` off suppresses `cpi` entirely, and the public override is
covered directly. 7/7 subtests pass.

## Dependency

Requires a Genesis build that provides the `cpi_name_for_az` hook
(RubidiumStudios/genesis#3). Without it, the kit's override is simply
never called by the base loop, so the az_map feature is inert — but the
kit still renders valid single-CPI cloud-config.