### PR TITLE
Require Genesis with the cpi_name_for_az hook

### DIFF
--- a/hooks/cloud-config-director.pm
+++ b/hooks/cloud-config-director.pm
@@ -15,7 +15,12 @@ use JSON::PP;
 sub init {
 	my $class = shift;
 	my $obj = $class->SUPER::init(@_);
-	$obj->check_minimum_genesis_version('3.1.0');
+	# 3.2.0-rc.16 is the first published Genesis release whose base
+	# AZ-definition loop calls cpi_name_for_az.  On anything older the
+	# override below is simply never invoked: az_map is silently
+	# ignored and every AZ falls back to the single cpi_name, which is
+	# valid cloud-config for the wrong topology.  Fail loudly instead.
+	$obj->check_minimum_genesis_version('3.2.0-rc.16');
 	return $obj;
 }
 

--- a/kit.yml
+++ b/kit.yml
@@ -9,7 +9,7 @@ docs:    https://github.com/genesis-community/bosh-genesis-kit
 code:    https://github.com/genesis-community/bosh-genesis-kit
 version: 4.1.0
 
-genesis_version_min: 2.8.12
+genesis_version_min: 3.2.0-rc.16
 use_create_env: allow
 
 services:


### PR DESCRIPTION
Follow-up to #149, which adopted the `cpi_name_for_az` extension point.

### The gap

`hooks/cloud-config-director.pm` overrides `cpi_name_for_az`, but the base AZ-definition loop in `Genesis::Hook::CloudConfig` only *calls* that override from **3.2.0-rc.16** onward. On anything older the override is never invoked — `bosh-configs.director-cpi.az_map` is silently discarded and every AZ falls back to the single `cpi_name`.

#149 documented this as acceptable degradation ("the az_map feature is inert — but the kit still renders valid single-CPI cloud-config"). That holds when nobody configured `az_map`. When somebody has, they get valid cloud-config describing the **wrong topology** — VMs placed against the wrong IaaS, with nothing logged. Malformed `az_map` keys still fail loudly via `_validate_az_map_keys`; a *valid* map is the one that vanishes silently.

Neither existing guard caught it:

| Guard | Was | Satisfied by an affected Genesis? |
|---|---|---|
| `hooks/cloud-config-director.pm` | `3.1.0` | yes |
| `kit.yml` `genesis_version_min` | `2.8.12` | yes — predates the kit being Perl at all |

### The change

Pin both to `3.2.0-rc.16`, the first published Genesis release whose base loop calls the hook. (rc.10 and earlier do not contain `fb8e9e75`; rc.11–15 were consumed by pipeline builds without ever being shipped.)

### Verification

Boundary-tested through `Genesis::new_enough`, the same comparator `check_minimum_genesis_version` uses:

```
genesis 3.1.0        vs min 3.2.0-rc.16  => BAILS
genesis 3.2.0-rc.6   vs min 3.2.0-rc.16  => BAILS
genesis 3.2.0-rc.15  vs min 3.2.0-rc.16  => BAILS
genesis 3.2.0-rc.16  vs min 3.2.0-rc.16  => allowed
genesis 3.2.0        vs min 3.2.0-rc.16  => allowed
```

The rc.6 case matters specifically: prerelease identifiers must compare numerically, not lexically, or `rc.6` would sort above `rc.16` and an affected build would slip through.

`spec/unit/cloud-config-director-az-map.t` passes 7/7 against a locally packed rc.16.

### Trade-off worth naming

This gates the whole kit on a prerelease, so anyone not yet on rc.16 can no longer use it at all — including envs that never touch `az_map` and would have worked fine. That is deliberate: the alternative is leaving a silent wrong-topology failure in place for the envs that *do* use it.

A narrower option exists — a capability probe that bails only when `az_map` is configured *and* the base lacks the hook, leaving everyone else unaffected. Design sketched but not implemented here; the pin is the simpler correct step now, and the two compose if the probe lands later.
