### PR TITLE
Emit pve CPI properties at their job spec paths

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -745,9 +745,11 @@ For a director that spans more than one independent CPI instance (for example, t
 
 `bosh-configs.director-cpi.cpis` and `bosh-configs.director-cpi.default` are a Genesis-core feature, not specific to this kit. When `bosh-configs.director-cpi.cpis` is present, Genesis uploads it **verbatim** as the director's cpi-config, bypassing this kit's `cpi-config` hook and its property defaults and name mapping entirely.
 
-**Property names are the CPI job spec's `pve_`-prefixed names** (`pve_host`, `pve_node`, `pve_api_token`, ...), not the unprefixed names this kit's own single-CPI hook accepts. An unprefixed name (`host`, `node`, ...) uploads without error and is silently ignored -- the CPI then runs that property on its job-spec default (or empty), which usually surfaces later as VM create failures rather than an upload-time error.
+**Property names are the CPI job spec's names, which are nested under `pve.`** (`pve.host`, `pve.node`, `pve.api_token`, ...) -- written as a `pve:` mapping in YAML, not as flat `pve_`-prefixed keys. `jobs/pve_cpi/spec` declares `pve.host`, and `jobs/pve_cpi/templates/cpi.json.erb` reads it as `p("pve.host")`; the same nested shape is what the kit renders into the director manifest's own `properties.pve:` block. A flat `pve_host` -- or an unprefixed `host` -- uploads without error and is silently ignored, and so does anything else that is not a declared property. The CPI then runs that property on its job-spec default (or empty), which usually surfaces later as VM create failures rather than an upload-time error.
 
-**Minimal-override rule:** set only the properties that genuinely differ per cluster -- typically `pve_host`, `pve_node`, `pve_storages`, and `pve_api_token`. Do **not** set `pve_agent_mbus` or `pve_password` on an entry unless the value truly differs from the job-level configuration: an explicit empty string in an override **clears** the job-level value instead of inheriting it, and a cleared mbus breaks agent bootstrap (`registry-less agent requires non-empty mbus`) on every VM that entry serves. Also omit `pve_host_operator` from entries -- it has no per-request override field, so the CPI logs a warning on every request that carries it.
+This bites hardest on the multi-CPI path precisely because it is silent: the director's own manifest already carries working values under `properties.pve:`, so a per-AZ entry whose keys are misnamed does not fail -- it just never diverges from az1. Every VM lands on the first cluster while `az_map` reports the topology you asked for.
+
+**Minimal-override rule:** set only the properties that genuinely differ per cluster -- typically `pve.host`, `pve.node`, `pve.vm_storage`/`pve.disk_storage`, and `pve.api_token`. Do **not** set `agent.mbus` or `pve.password` on an entry unless the value truly differs from the job-level configuration: an explicit empty string in an override **clears** the job-level value instead of inheriting it, and a cleared mbus breaks agent bootstrap (`registry-less agent requires non-empty mbus`) on every VM that entry serves. Also omit `pve_host_operator` from entries -- it is a kit-level param for the `create-env` operator-side API address, not a CPI job property, so it is ignored here.
 
 ```yaml
 bosh-configs:
@@ -757,17 +759,21 @@ bosh-configs:
     - name: <bloc>-<env>.pve.bosh           # az1
       type: pve
       properties:
-        pve_host:     <az1-host>
-        pve_node:     <az1-node>
-        pve_storages: [ nfs-images ]
-        pve_api_token: ((/cpi-config/properties/pve-api-token-az1))
+        pve:
+          host:         <az1-host>
+          node:         <az1-node>
+          vm_storage:   nfs-images
+          disk_storage: nfs-images
+          api_token:    ((/cpi-config/properties/pve-api-token-az1))
     - name: <bloc>-<env>.pve-az2.bosh       # az2
       type: pve
       properties:
-        pve_host:     <az2-host>
-        pve_node:     <az2-node>
-        pve_storages: [ nfs-images ]
-        pve_api_token: ((/cpi-config/properties/pve-api-token-az2))
+        pve:
+          host:         <az2-host>
+          node:         <az2-node>
+          vm_storage:   nfs-images
+          disk_storage: nfs-images
+          api_token:    ((/cpi-config/properties/pve-api-token-az2))
 ```
 
 **Secrets under `properties:` do not use `(( vault ... ))`.** Genesis's inline `director-cpi` upload path does not resolve `(( vault ... ))` inside `cpis[].properties`. A literal `(( vault ))` string uploads without error and only fails at first interpolation -- which poisons every subsequent cpi-config-consuming operation (stemcell upload, cloud-check, resurrection) until a corrective redeploy. Instead, pre-set each token directly in the director's own credhub (vault -> credhub, output suppressed) and reference it in the env file by its absolute credhub path, as shown above.

--- a/ci/tasks/spec-tests.yml
+++ b/ci/tasks/spec-tests.yml
@@ -14,4 +14,4 @@ inputs:
 run:
   dir: git
   path: prove
-  args: [ "-lv", "spec/spec.t", "spec/unit/cloud-config-director-az-map.t" ]
+  args: [ "-lv", "spec/spec.t", "spec/unit/cloud-config-director-az-map.t", "spec/unit/cpi-config-pve-property-paths.t" ]

--- a/hooks/cpi-config.pm
+++ b/hooks/cpi-config.pm
@@ -163,7 +163,7 @@ sub _property_map_for_pve {
 		pve_vmid_range_start@vmid_range_start:200
 		pve_agent_mode@agent_mode:cloudinit
 		pve_vm_disk_format@vm_disk_format:raw
-		pve_agent_mbus@agent.mbus:""
+		pve_agent_mbus@agent.mbus:"">agent.mbus
 	/;
 }
 # }}}

--- a/hooks/cpi-config.pm
+++ b/hooks/cpi-config.pm
@@ -42,7 +42,7 @@ sub perform {
 		'stackit'   => sub { $self->gather_properties($self->_property_map_for_stackit) },
 		'vsphere'   => sub { $self->gather_properties($self->_property_map_for_vsphere) },
 		'aws'       => sub { $self->gather_properties($self->_property_map_for_aws) },
-		'pve'       => sub { $self->gather_properties($self->_property_map_for_pve) },
+		'pve'       => sub { $self->gather_properties_for_pve },
 	);
 	$self->done($config);
 }
@@ -134,7 +134,6 @@ sub _property_map_for_aws {
 		http_tokens:required>metadata_options.http_tokens
 		http_put_response_hop_limit?>metadata_options.http_put_response_hop_limit
 	/;
-	# use_v4_signature:true - disabled for now
 }
 
 # PVE CPI configuration properties
@@ -144,27 +143,88 @@ sub _property_map_for_aws {
 # Required fields (!) must be present in the env yml bosh-configs.cpi block.
 # Optional fields (?) are omitted when absent.
 # Default values (:value) are used when the key is absent.
-# Property names verified against jobs/pve_cpi/spec.
+#
+# Every entry carries an explicit >path because the OCFP lookup key and the
+# job property are not the same name: jobs/pve_cpi/spec declares these under
+# the `pve.` namespace (pve.host, pve.node, ...) plus the shared `agent.mbus`,
+# while the env yml keys them flat as pve_host, pve_node, ... Without >path
+# the emitted property name defaults to the lookup key, so the whole block
+# landed at the top level where jobs/pve_cpi/templates/cpi.json.erb -- which
+# reads p("pve.host"), p("pve.node"), if_p("agent.mbus") -- never saw it.
 sub _property_map_for_pve {
 	qw/
-		!pve_host@host
-		pve_port@port:8006
-		!pve_user@user
-		pve_realm@realm:pam
-		pve_password@password:""
-		pve_api_token@api_token?
-		!pve_node@node
-		pve_vm_storage@vm_storage:local-lvm
-		pve_disk_storage@disk_storage:local-lvm
-		pve_stemcell_storage@stemcell_storage:local
-		pve_iso_storage@iso_storage:local
-		pve_network_bridge@network_bridge:vmbr0
-		pve_verify_ssl@verify_ssl:true
-		pve_vmid_range_start@vmid_range_start:200
-		pve_agent_mode@agent_mode:cloudinit
-		pve_vm_disk_format@vm_disk_format:raw
+		!pve_host@host>pve.host
+		pve_port@port:8006>pve.port
+		!pve_user@user>pve.user
+		pve_realm@realm:pam>pve.realm
+		pve_password@password:"">pve.password
+		pve_api_token@api_token?>pve.api_token
+		!pve_node@node>pve.node
+		pve_vm_storage@vm_storage:local-lvm>pve.vm_storage
+		pve_disk_storage@disk_storage:local-lvm>pve.disk_storage
+		pve_stemcell_storage@stemcell_storage:local>pve.stemcell_storage
+		pve_iso_storage@iso_storage:local>pve.iso_storage
+		pve_network_bridge@network_bridge:vmbr0>pve.network_bridge
+		pve_verify_ssl@verify_ssl:true>pve.verify_ssl
+		pve_vmid_range_start@vmid_range_start:200>pve.vmid_range_start
+		pve_agent_mode@agent_mode:cloudinit>pve.agent_mode
+		pve_vm_disk_format@vm_disk_format:raw>pve.vm_disk_format
 		pve_agent_mbus@agent.mbus:"">agent.mbus
 	/;
+}
+
+# gather_properties, then drop the source keys the pve map already consumed.
+#
+# gather_properties keys its working hash by the *output path*, but its
+# trailing manual-override pass -- the one that lets an environment set CPI
+# properties the kit does not model -- keys off the bosh-configs.cpi *source
+# key*. While path and key were identical those two agreed. Every entry in
+# the pve map now sets an explicit >path, so each source key the operator
+# actually set in their env yml fails that pass's `exists $config{$override}`
+# guard and is copied back in verbatim at the top level, beside the correctly
+# nested value.
+#
+# The duplicate is not cosmetic, because the override pass copies the value
+# neither entombed nor evaluated:
+#
+#   - `!` secrets are re-emitted in cleartext. pve_host, pve_user and pve_node
+#     resolve to a ((/cpi-config/properties/...)) credhub reference under
+#     pve.*, and then the raw value reappears as top-level pve_host, pve_user,
+#     pve_node. That defeats the entombment the `!` exists to perform.
+#
+#   - a spruce operator is copied as a literal and reaches the director as a
+#     BOSH variable reference, which fails every deployment against that
+#     director until the operator rewrites it as a literal:
+#       Variable name ' concat "nats://" params.static_ip ":4222" ' must only
+#       contain alphanumeric, underscores, dashes, or forward slash characters
+#
+# Only keys this map itself consumed are removed -- its lookup key and any
+# @alternates, and only when they resolved to a different output path. Genuine
+# passthrough of keys the kit does not model is untouched, which is what the
+# override pass is for.
+sub gather_properties_for_pve {
+	my ($self) = @_;
+
+	my @map = $self->_property_map_for_pve;
+	my $properties = $self->gather_properties(@map);
+
+	for my $property (@map) {
+		# Same parse as Genesis::Hook::CpiConfig::gather_properties:
+		#   [!]property_name[@alternate_lookup][:default_value|?][>config_path]
+		my (undef, $key, $alts, undef, undef, $path) =
+			$property =~ /^(!?)([^\@:\?\>]+)(?:\@([^:\?\>]+))?(?:(?::([^>]+))|(\?))?(?:>(.+))?$/;
+
+		# No >path means the output name already is the source key: the value
+		# sitting at that key is the mapped value, not a duplicate of it.
+		next unless defined $path;
+
+		for my $source ($key, split(/,/, $alts // '')) {
+			next if $source eq $path;
+			delete $properties->{$source};
+		}
+	}
+
+	return $properties;
 }
 # }}}
 

--- a/spec/deployments/pve-multi-az.yml
+++ b/spec/deployments/pve-multi-az.yml
@@ -30,8 +30,11 @@ params:
 # the new keys pass cleanly through env-file processing without altering
 # the rendered director manifest.
 #
-# Property names are the CPI job-spec `pve_`-prefixed names (genesis
+# Property names are the CPI job-spec names, nested under `pve.` (genesis
 # uploads cpis[] verbatim -- see MANUAL.md's Multi-AZ / Multi-CPI section).
+# jobs/pve_cpi/spec declares pve.host / pve.node / ..., and cpi.json.erb
+# reads them as p("pve.host"); a flat pve_host uploads fine and is then
+# silently ignored, leaving the entry to inherit az1's values.
 # api_token values are director-credhub path references, matching the
 # live-validated pattern; they are not vault references and not secrets.
 # az_map is keyed by OCFP vault AZ key names (net/azs/*), not by the
@@ -45,39 +48,41 @@ bosh-configs:
     - name: pve-cpi
       type: pve
       properties:
-        pve_host: test-pve-host
-        pve_port: 8006
-        pve_user: test-pve-user
-        pve_realm: pam
-        pve_api_token: ((/cpi-config/properties/pve-api-token-az1))
-        pve_node: test-pve-node
-        pve_vm_storage: test-vm-storage
-        pve_disk_storage: test-disk-storage
-        pve_stemcell_storage: local
-        pve_iso_storage: local
-        pve_network_bridge: test-bridge
-        pve_verify_ssl: true
-        pve_vmid_range_start: 200
-        pve_agent_mode: cloudinit
-        pve_vm_disk_format: raw
+        pve:
+          host: test-pve-host
+          port: 8006
+          user: test-pve-user
+          realm: pam
+          api_token: ((/cpi-config/properties/pve-api-token-az1))
+          node: test-pve-node
+          vm_storage: test-vm-storage
+          disk_storage: test-disk-storage
+          stemcell_storage: local
+          iso_storage: local
+          network_bridge: test-bridge
+          verify_ssl: true
+          vmid_range_start: 200
+          agent_mode: cloudinit
+          vm_disk_format: raw
     - name: pve-cpi-az2
       type: pve
       properties:
-        pve_host: test-pve-host-az2
-        pve_port: 8006
-        pve_user: test-pve-user
-        pve_realm: pam
-        pve_api_token: ((/cpi-config/properties/pve-api-token-az2))
-        pve_node: test-pve-node-az2
-        pve_vm_storage: test-vm-storage
-        pve_disk_storage: test-disk-storage
-        pve_stemcell_storage: local
-        pve_iso_storage: local
-        pve_network_bridge: test-bridge
-        pve_verify_ssl: true
-        pve_vmid_range_start: 200
-        pve_agent_mode: cloudinit
-        pve_vm_disk_format: raw
+        pve:
+          host: test-pve-host-az2
+          port: 8006
+          user: test-pve-user
+          realm: pam
+          api_token: ((/cpi-config/properties/pve-api-token-az2))
+          node: test-pve-node-az2
+          vm_storage: test-vm-storage
+          disk_storage: test-disk-storage
+          stemcell_storage: local
+          iso_storage: local
+          network_bridge: test-bridge
+          verify_ssl: true
+          vmid_range_start: 200
+          agent_mode: cloudinit
+          vm_disk_format: raw
     az_map:
       pvea: pve-cpi
       pved: pve-cpi-az2

--- a/spec/results/pve-multi-az.yml
+++ b/spec/results/pve-multi-az.yml
@@ -6,39 +6,41 @@ bosh-configs:
     cpis:
     - name: pve-cpi
       properties:
-        pve_agent_mode: cloudinit
-        pve_api_token: test-pve-api-token-az1
-        pve_disk_storage: test-disk-storage
-        pve_host: test-pve-host
-        pve_iso_storage: local
-        pve_network_bridge: test-bridge
-        pve_node: test-pve-node
-        pve_port: 8006
-        pve_realm: pam
-        pve_stemcell_storage: local
-        pve_user: test-pve-user
-        pve_verify_ssl: true
-        pve_vm_disk_format: raw
-        pve_vm_storage: test-vm-storage
-        pve_vmid_range_start: 200
+        pve:
+          agent_mode: cloudinit
+          api_token: test-pve-api-token-az1
+          disk_storage: test-disk-storage
+          host: test-pve-host
+          iso_storage: local
+          network_bridge: test-bridge
+          node: test-pve-node
+          port: 8006
+          realm: pam
+          stemcell_storage: local
+          user: test-pve-user
+          verify_ssl: true
+          vm_disk_format: raw
+          vm_storage: test-vm-storage
+          vmid_range_start: 200
       type: pve
     - name: pve-cpi-az2
       properties:
-        pve_agent_mode: cloudinit
-        pve_api_token: test-pve-api-token-az2
-        pve_disk_storage: test-disk-storage
-        pve_host: test-pve-host-az2
-        pve_iso_storage: local
-        pve_network_bridge: test-bridge
-        pve_node: test-pve-node-az2
-        pve_port: 8006
-        pve_realm: pam
-        pve_stemcell_storage: local
-        pve_user: test-pve-user
-        pve_verify_ssl: true
-        pve_vm_disk_format: raw
-        pve_vm_storage: test-vm-storage
-        pve_vmid_range_start: 200
+        pve:
+          agent_mode: cloudinit
+          api_token: test-pve-api-token-az2
+          disk_storage: test-disk-storage
+          host: test-pve-host-az2
+          iso_storage: local
+          network_bridge: test-bridge
+          node: test-pve-node-az2
+          port: 8006
+          realm: pam
+          stemcell_storage: local
+          user: test-pve-user
+          verify_ssl: true
+          vm_disk_format: raw
+          vm_storage: test-vm-storage
+          vmid_range_start: 200
       type: pve
     default: pve-cpi
 exodus:

--- a/spec/unit/cpi-config-pve-property-paths.t
+++ b/spec/unit/cpi-config-pve-property-paths.t
@@ -1,0 +1,307 @@
+#!/usr/bin/env perl
+# Unit tests for the pve CPI property map in hooks/cpi-config.pm.
+#
+# hooks/cpi-config.pm only runs for OCFP environments, and spec/spec.t has
+# no ocfp env: the ocfp feature needs bloc config in vault
+# (secret/config/<bloc>/...) and a live create-env, neither of which the
+# validator sandbox provides (see the NOTE in spec/spec.t). So none of
+# spec/deployments/pve*.yml exercise this hook at all, and the pve map's
+# emitted property *names* were never checked against jobs/pve_cpi/spec.
+# They did not match: every entry emitted a flat name (pve_host) where the
+# job declares a nested one (pve.host), so nothing the map produced was
+# ever read by jobs/pve_cpi/templates/cpi.json.erb.
+#
+# This file loads the real hook module directly and drives
+# gather_properties_for_pve against thin test doubles for the env-side
+# collaborators, so the code under test -- the kit's _property_map_for_pve
+# and gather_properties_for_pve, plus the base class's gather_properties
+# parse/lookup/entomb/override/unflatten pipeline -- runs unmodified.
+#
+# Required cases:
+#   (a) every mapped property lands at the path jobs/pve_cpi/spec declares,
+#       and nothing is left at the top level under its env-yml key.
+#   (b) `!` secrets are entombed and appear ONLY as a credhub reference.
+#       This is the regression that makes the >path change unsafe on its
+#       own: gather_properties' manual-override pass keys off the source
+#       key while the config hash is keyed by output path, so once they
+#       diverge the raw secret is copied back in beside its own reference.
+#   (c) a spruce operator in a mapped key never reaches the top level. The
+#       cpi-config is uploaded unevaluated, and the director parses a bare
+#       (( ... )) as a BOSH variable reference, failing every deployment
+#       against it.
+#   (d) keys the map does NOT model still pass through, because that is
+#       what the override pass is for.
+use strict;
+use warnings;
+use FindBin;
+use Test::More;
+
+my $hook_file = "$FindBin::Bin/../../hooks/cpi-config.pm";
+require $hook_file;
+
+# --- Test doubles ------------------------------------------------------
+
+package Test::FakeEnv;
+
+sub new {
+	my ($class, %opts) = @_;
+	return bless { data => $opts{data} // {} }, $class;
+}
+
+# Minimal stand-in for Genesis::Env::lookup. gather_properties calls this in
+# list context and treats the second element as "found", so the found flag
+# has to be real: returning a bare undef value would send every lookup down
+# the ocfp_config_lookup fallback instead.
+sub lookup {
+	my ($self, $key, $default) = @_;
+	my @path = split /\./, $key;
+	my $node = $self->{data};
+	for my $seg (@path) {
+		return (wantarray ? ($default, 0) : $default)
+			unless ref($node) eq 'HASH' && exists $node->{$seg};
+		$node = $node->{$seg};
+	}
+	return wantarray ? ($node, 1) : $node;
+}
+
+# The env yml is not spruce-evaluated here, which matches the real
+# lookup_unevaled: the override pass deliberately reads raw values.
+sub lookup_unevaled {
+	my ($self, $key) = @_;
+	return $self->lookup($key, {});
+}
+
+# No OCFP bloc config in the sandbox; every lookup falls through to the
+# map's declared default.
+sub ocfp_config_lookup { return (undef, 0) }
+
+sub cpi_credhub_base { '/cpi-config/properties/' }
+
+package Test::FakeCpiConfig;
+
+# Inherit the real hook module under test -- _property_map_for_pve and
+# gather_properties_for_pve are NOT overridden here, so they run as
+# shipped. Only the env-side collaborators are stubbed.
+our @ISA = ('Genesis::Hook::CpiConfig::BOSH');
+
+sub new {
+	my ($class, %opts) = @_;
+	return bless {
+		env             => $opts{env},
+		credhub_secrets => {},
+	}, $class;
+}
+
+sub env  { $_[0]->{env} }
+sub iaas { 'pve' }
+
+package main;
+
+# The bosh-configs.cpi block an operator actually writes: flat pve_* keys.
+sub build_hook {
+	my (%cpi) = @_;
+	my $env = Test::FakeEnv->new(
+		data => { 'bosh-configs' => { cpi => \%cpi } },
+	);
+	return Test::FakeCpiConfig->new(env => $env);
+}
+
+my %BASE_CPI = (
+	pve_host           => '10.115.16.1',
+	pve_user           => 'ocfp-cpi@pve',
+	pve_node           => 'lab-pipes-0',
+	pve_vm_storage     => 'local-lvm-data',
+	pve_disk_storage   => 'local-lvm-data',
+	pve_network_bridge => 'ocfp',
+	pve_verify_ssl     => 0,
+	pve_agent_mbus     => 'nats://10.115.16.4:4222',
+);
+
+# Property names as declared in jobs/pve_cpi/spec of bosh-pve-cpi-release,
+# and read back by jobs/pve_cpi/templates/cpi.json.erb via p("pve.host"),
+# p("pve.node"), ... and if_p("agent.mbus"). Nothing the map emits is read
+# by the job unless it arrives at one of these paths.
+my %EXPECTED_SPEC_PATHS = (
+	'pve.host'             => undef,  # from bosh-configs.cpi, entombed
+	'pve.port'             => 8006,
+	'pve.user'             => undef,  # entombed
+	'pve.realm'            => 'pam',
+	'pve.password'         => '',
+	'pve.node'             => undef,  # entombed
+	'pve.vm_storage'       => 'local-lvm-data',
+	'pve.disk_storage'     => 'local-lvm-data',
+	'pve.stemcell_storage' => 'local',
+	'pve.iso_storage'      => 'local',
+	'pve.network_bridge'   => 'ocfp',
+	'pve.verify_ssl'       => 0,
+	'pve.vmid_range_start' => 200,
+	'pve.agent_mode'       => 'cloudinit',
+	'pve.vm_disk_format'   => 'raw',
+	'agent.mbus'           => 'nats://10.115.16.4:4222',
+);
+
+# Walk a dotted path into the unflattened config.
+sub at_path {
+	my ($config, $path) = @_;
+	my $node = $config;
+	for my $seg (split /\./, $path) {
+		return undef unless ref($node) eq 'HASH' && exists $node->{$seg};
+		$node = $node->{$seg};
+	}
+	return $node;
+}
+
+# --- (a) every mapped property lands at its jobs/pve_cpi/spec path ------
+subtest 'every mapped property is emitted at the path jobs/pve_cpi/spec declares' => sub {
+	my $config = build_hook(%BASE_CPI)->gather_properties_for_pve;
+
+	for my $path (sort keys %EXPECTED_SPEC_PATHS) {
+		my @segs = split /\./, $path;
+		my $leaf = pop @segs;
+		my $parent = at_path($config, join('.', @segs));
+		ok(
+			ref($parent) eq 'HASH' && exists $parent->{$leaf},
+			"$path is present at its nested spec path (cpi.json.erb reads it as p(\"$path\"))",
+		);
+	}
+
+	# The whole point: the pve namespace is a nested hash, not a set of
+	# top-level pve_-prefixed keys.
+	is(ref($config->{pve}), 'HASH', 'pve properties are nested under a pve hash, not flattened into pve_* keys');
+	is(ref($config->{agent}), 'HASH', 'agent.mbus is nested under an agent hash');
+};
+
+subtest 'mapped defaults and env values arrive with the right values' => sub {
+	my $config = build_hook(%BASE_CPI)->gather_properties_for_pve;
+
+	for my $path (sort keys %EXPECTED_SPEC_PATHS) {
+		my $expected = $EXPECTED_SPEC_PATHS{$path};
+		next unless defined $expected;   # entombed secrets checked in (b)
+		is(at_path($config, $path), $expected, "$path carries its expected value");
+	}
+};
+
+# --- no source key is left behind at the top level ---------------------
+subtest 'no env-yml source key is left at the top level alongside its mapped path' => sub {
+	my $config = build_hook(%BASE_CPI)->gather_properties_for_pve;
+
+	my @stray = sort grep { /^pve_/ } keys %$config;
+	is_deeply(
+		\@stray, [],
+		'no pve_* key survives at the top level; every one resolved to its pve.* path',
+	);
+};
+
+# --- (b) `!` secrets stay entombed, with no cleartext twin -------------
+subtest 'secret properties are entombed and never duplicated in cleartext' => sub {
+	my $hook   = build_hook(%BASE_CPI);
+	my $config = $hook->gather_properties_for_pve;
+
+	my %secret_source_for = (
+		'pve.host' => 'pve_host',
+		'pve.user' => 'pve_user',
+		'pve.node' => 'pve_node',
+	);
+
+	for my $path (sort keys %secret_source_for) {
+		my $value = at_path($config, $path);
+		like(
+			$value, qr{^\(\(/cpi-config/properties/cpi-config-property--\Q$path\E--[0-9a-f]{8}\)\)$},
+			"$path is a credhub reference, not the raw value",
+		);
+	}
+
+	# The regression this guards: gather_properties' override pass keys off
+	# the source key while the config hash is keyed by output path, so once
+	# a >path is introduced the raw secret is copied straight back in.
+	for my $path (sort keys %secret_source_for) {
+		my $source = $secret_source_for{$path};
+		ok(
+			!exists $config->{$source},
+			"raw secret is not re-emitted as top-level $source beside the entombed $path",
+		);
+	}
+
+	my $cleartext = join "\n", map { "$_" } grep { !ref } values %$config;
+	unlike($cleartext, qr/\Q$BASE_CPI{pve_user}\E/, 'pve_user cleartext appears nowhere at the top level');
+	unlike($cleartext, qr/\Q$BASE_CPI{pve_node}\E/, 'pve_node cleartext appears nowhere at the top level');
+
+	# The entombed values are still handed to credhub, so the reference resolves.
+	my %entombed = map { $_ => 1 } values %{$hook->{credhub_secrets}};
+	ok($entombed{$BASE_CPI{pve_host}}, 'pve_host value was handed to credhub for entombment');
+	ok($entombed{$BASE_CPI{pve_user}}, 'pve_user value was handed to credhub for entombment');
+	ok($entombed{$BASE_CPI{pve_node}}, 'pve_node value was handed to credhub for entombment');
+};
+
+# --- (c) a spruce operator never reaches the top level -----------------
+subtest 'a spruce operator in a mapped key does not leak to the top level' => sub {
+	my $config = build_hook(
+		%BASE_CPI,
+		pve_agent_mbus => '(( concat "nats://" params.static_ip ":4222" ))',
+	)->gather_properties_for_pve;
+
+	ok(
+		!exists $config->{pve_agent_mbus},
+		'unevaluated operator is not copied to a top-level pve_agent_mbus',
+	);
+
+	# Left at the top level, the director parses the bare (( ... )) as a BOSH
+	# variable reference and rejects every deployment against it:
+	#   Variable name ' concat "nats://" ... ' must only contain alphanumeric,
+	#   underscores, dashes, or forward slash characters
+	my @operator_keys = sort grep {
+		!ref($config->{$_}) && defined($config->{$_}) && $config->{$_} =~ /^\(\(\s*\w+\s/
+	} keys %$config;
+	is_deeply(\@operator_keys, [], 'no top-level key carries an unevaluated spruce operator');
+};
+
+# --- (d) unmodeled keys still pass through -----------------------------
+subtest 'keys the map does not model are still passed through' => sub {
+	my $config = build_hook(
+		%BASE_CPI,
+		pve_log_level  => 'debug',        # real spec property, not in the map
+		some_other_key => 'passthrough',  # not a pve property at all
+	)->gather_properties_for_pve;
+
+	is($config->{pve_log_level}, 'debug', 'an unmapped pve_* key is left for the override pass to carry');
+	is($config->{some_other_key}, 'passthrough', 'an unrelated override key is untouched');
+};
+
+# --- optional properties stay optional ---------------------------------
+subtest 'optional pve_api_token is omitted when unset and nested when set' => sub {
+	my $without = build_hook(%BASE_CPI)->gather_properties_for_pve;
+	ok(!exists $without->{pve}{api_token}, 'pve.api_token is omitted when the env does not set it');
+	ok(!exists $without->{pve_api_token}, 'and no top-level pve_api_token appears either');
+
+	my $with = build_hook(%BASE_CPI, pve_api_token => 'ocfp-cpi@pve!cpi=uuid')->gather_properties_for_pve;
+	is($with->{pve}{api_token}, 'ocfp-cpi@pve!cpi=uuid', 'pve.api_token is nested at its spec path when set');
+	ok(!exists $with->{pve_api_token}, 'and is not duplicated at the top level');
+};
+
+# --- the map itself is well-formed -------------------------------------
+subtest 'every pve map entry declares an explicit output path' => sub {
+	my @map = Test::FakeCpiConfig->_property_map_for_pve;
+	is(scalar(@map), 17, 'the pve map has 17 entries');
+
+	for my $property (@map) {
+		my (undef, $key, undef, undef, undef, $path) =
+			$property =~ /^(!?)([^\@:\?\>]+)(?:\@([^:\?\>]+))?(?:(?::([^>]+))|(\?))?(?:>(.+))?$/;
+		ok(defined $path, "$key declares an explicit >path");
+		like($path // '', qr/^(pve|agent)\./, "$key targets a nested spec namespace (pve.* or agent.*)");
+	}
+
+	my %paths = map {
+		my (undef, undef, undef, undef, undef, $p) =
+			$_ =~ /^(!?)([^\@:\?\>]+)(?:\@([^:\?\>]+))?(?:(?::([^>]+))|(\?))?(?:>(.+))?$/;
+		($p => 1)
+	} @map;
+	# pve.api_token is optional, so it is absent from the default-render
+	# expectations above but must still be declared by the map.
+	is_deeply(
+		[sort keys %paths],
+		[sort (keys %EXPECTED_SPEC_PATHS, 'pve.api_token')],
+		'the map targets exactly the jobs/pve_cpi/spec property set it claims to',
+	);
+};
+
+done_testing;


### PR DESCRIPTION
The pve CPI config never carried `agent.mbus`, so no BOSH director deployed with this kit on Proxmox could create a VM. Investigating that turned out to expose the whole pve property map, so this PR now fixes all 16 entries rather than the one.

### What happens

Every director-issued `create_vm` fails during compilation:

```
Error: CPI error 'Bosh::Clouds::CloudError' with message
'create_vm: registry-less agent requires non-empty mbus (agent.mbus in CPI config)'
in 'create_vm' CPI method
```

The director itself comes up fine, which makes this easy to misread as a deployment-specific problem. `create-env` passes its own bootstrap mbus (`https://mbus:...@<ip>:6868`) and never consults the CPI config, so only director-deployed VMs break — the first thing you hit after the director is healthy.

### Cause

In `gather_properties` the `@alt` suffix is only an *alternate lookup key*. The output path defaults to the property name unless `>path` is given:

```perl
#   [!]property_name[@alternate_lookup][:default_value|?][>config_path]
$path //= $key;
```

So `pve_agent_mbus@agent.mbus:""` emitted a flat `pve_agent_mbus` into the generated cpi-config, while `jobs/pve_cpi/templates/cpi.json.erb` reads it as a nested property:

```ruby
if_p("agent.mbus") { |v| config["agent_mbus"] = v }
```

The value never reached the CPI.

### The rest of the map had the same defect

The map's block comment claimed "Property names verified against `jobs/pve_cpi/spec`". That did not hold for a single entry. The spec declares everything nested under `pve.`:

```yaml
pve.host:
pve.node:
pve.vm_storage:
```

and `cpi.json.erb` reads `p("pve.host")`, `p("pve.node")`, … The map emitted flat `pve_host`, `pve_node`, … so **nothing it produced was ever read by the job**. The kit already renders the correct nested shape into the director's own manifest — see `spec/results/pve.yml`'s `properties.pve:` block — which is exactly why this stayed invisible: working values reached the CPI from `cloud_provider.properties`, leaving the cpi-config inert rather than wrong-valued.

Inert is not harmless. It stops being inert on the multi-CPI path, where a per-AZ entry is the only source of its own values, and it was never inert for `agent.mbus`, which has no manifest-side equivalent.

All 16 entries now carry an explicit `>path`.

### Why the `>path` fix needed a second change

`gather_properties` keys its config hash by *output path*, but its trailing manual-override pass — the one that lets an environment set properties the kit does not model — keys off the bosh-configs.cpi *source key*:

```perl
next if exists $config{$override};
```

While path and key were identical those two agreed. Once they diverge, every source key the operator actually set fails that guard and is copied back in at the top level, unevaluated and un-entombed. Observed directly against the real hook:

```json
{
   "pve" : {
      "host" : "((/cpi-config/properties/cpi-config-property--pve.host--97cb0e7d))",
      "node" : "((/cpi-config/properties/cpi-config-property--pve.node--219445f5))"
   },
   "pve_host" : "10.115.16.1",
   "pve_node" : "lab-pipes-0"
}
```

Two consequences, both real:

- **`!` secrets are re-emitted in cleartext** beside their own credhub reference, defeating the entombment the `!` exists to perform. `pve_host`, `pve_user` and `pve_node` are all `!`.
- **A spruce operator is copied as a literal** and reaches the director as a BOSH variable reference, failing every deployment against that director until the operator rewrites it: `Variable name ' concat "nats://" params.static_ip ":4222" ' must only contain alphanumeric, underscores, dashes, or forward slash characters`.

`gather_properties_for_pve` drops the map's own source keys after gathering — only keys this map consumed, and only when they resolved to a different path, so genuine passthrough of unmodelled keys is untouched:

```json
{
   "pve" : { "host" : "((/cpi-config/...))", "vm_storage" : "local-lvm-data" },
   "agent" : { "mbus" : "nats://10.115.16.4:4222" },
   "pve_log_level" : "debug"
}
```

This is a workaround for a Genesis-core bug that affects any kit using `>path` with a source key an operator can set. The openstack, stackit and aws maps all have `>path` entries (`connection_options.read_timeout`, `root_disk.size`, `metadata_options.*`), so they are exposed to the same duplication today; none of them combine it with `!`, so none currently leak a secret. Worth fixing in `Genesis::Hook::CpiConfig` so kits do not each need this — happy to open that separately.

### MANUAL.md said the same wrong thing

`bosh-configs.director-cpi.cpis` is uploaded verbatim, bypassing this hook entirely, and the manual told operators to use the flat names — asserting they were "the CPI job spec's `pve_`-prefixed names" and warning that *unprefixed* names get silently ignored. Both halves are inverted.

This is the worst place for it to be wrong, because it is silent by construction: a misnamed per-AZ entry does not fail, since the director's manifest already carries working values under `properties.pve:`. The entry simply never diverges from az1 — every VM lands on the first cluster while `az_map` reports the topology the operator asked for.

The guidance and example are now a nested `pve:` mapping, with the `pve-multi-az` fixtures updated to match. Two smaller corrections came with it: `pve_storages` in the example does not exist in the job spec under any spelling (replaced with `vm_storage`/`disk_storage`), and `pve_host_operator` is a kit param for the create-env operator-side API address rather than a CPI job property.

### Tests

`spec/spec.t` has no ocfp env — the feature needs bloc config in vault and a live create-env, neither of which the validator sandbox provides — so `hooks/cpi-config.pm` had no test coverage at all, which is how the map's names went unverified. `spec/unit/cpi-config-pve-property-paths.t` loads the hook directly against env doubles, following `spec/unit/cloud-config-director-az-map.t`, and covers: every property emitted at its spec path, no source key left at the top level, secrets entombed with no cleartext twin, no unevaluated operator at the top level, unmodelled keys still passed through, and the optional `pve_api_token`. Registered in `ci/tasks/spec-tests.yml`.

Verified red: with the source-key drop bypassed, 4 of the 8 subtests fail, including the secret-leak one.

### Verification

Applied against a live Proxmox lab. Before: every compilation VM failed as above. After: `agent: {mbus: nats://10.115.16.4:4222}` appears nested in the uploaded cpi-config, a Concourse deployment reached 5 running instances, and its pipeline ran to a successful build.
